### PR TITLE
return token as string

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1736,7 +1736,7 @@ class CobblerXMLRPCInterface(object):
         urandom = open("/dev/urandom", 'rb')
         b64 = base64.encodestring(urandom.read(length))
         urandom.close()
-        return b64
+        return b64.decode()
 
     def __make_token(self, user):
         """


### PR DESCRIPTION
The token should be a string and not bytes.

Let __get_random() return already a string