### PR TITLE
Add options and identity-file power options and remove power templates

### DIFF
--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -64,6 +64,8 @@ FIELDS = [
     ["power_pass", "", 0, "Power Management Password", True, "", 0, "str"],
     ["power_type", "SETTINGS:power_management_default_type", 0, "Power Management Type", True, "Power management script to use", power_manager.get_power_types(), "str"],
     ["power_user", "", 0, "Power Management Username", True, "", 0, "str"],
+    ["power_options", "", 0, "Power Management Options", True, "Additional options, to be passed to the fencing agent", 0, "str"],
+    ["power_identity_file", "", 0, "Power Identity File", True, "Identity file to be passed to the fencing agent (ssh key)", 0, "str"],
     ["profile", None, 0, "Profile", True, "Parent profile", [], "str"],
     ["proxy", "<<inherit>>", 0, "Internal Proxy", True, "Internal proxy URL", 0, "str"],
     ["redhat_management_key", "<<inherit>>", 0, "Redhat Management Key", True, "Registration key for RHN, Spacewalk, or Satellite", 0, "str"],
@@ -639,6 +641,18 @@ class System(item.Item):
             power_type = ""
         power_manager.validate_power_type(power_type)
         self.power_type = power_type
+
+    def set_power_identity_file(self, power_identity_file):
+        if power_identity_file is None:
+            power_identity_file = ""
+        utils.safe_filter(power_identity_file)
+        self.power_identity_file = power_identity_file
+
+    def set_power_options(self, power_options):
+        if power_options is None:
+            power_options = ""
+        utils.safe_filter(power_options)
+        self.power_options = power_options
 
     def set_power_user(self, power_user):
         if power_user is None:

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -27,6 +27,8 @@ from builtins import range
 from builtins import object
 import glob
 import os
+from pathlib import Path
+import stat
 import re
 import time
 
@@ -35,6 +37,9 @@ from . import clogger
 from . import templar
 from . import utils
 
+# Try the power command 3 times before giving up.
+# Some power switches are flakey
+POWER_RETRIES=3
 
 def get_power_types():
     """
@@ -108,6 +113,64 @@ class PowerManager(object):
             logger = clogger.Logger()
         self.logger = logger
 
+    def _check_power_conf(self, system, logger, user, password):
+        """
+        Prints a warning for invalid power configuraitons
+        @param System system Cobbler system
+        @param Logger logger logger
+        """
+
+        if (system.power_pass or password) and system.power_identity_file:
+            logger.warning("Both password and identity-file are specified")
+        if system.power_identity_file:
+            ident_path = Path(system.power_identity_file)
+            if not ident_path.exists():
+                logger.warning("identity-file " + system.power_identity_file + " does not exist")
+            else:
+                ident_stat = stat.S_IMODE(ident_path.stat().st_mode)
+                if (ident_stat & stat.S_IRWXO) or (ident_stat & stat.S_IRWXG):
+                    logger.warning("identity-file " + system.power_identity_file +
+                                   " must not be read/write/exec by group or others")
+        if not system.power_address:
+            logger.warning("power-address is missing")
+        if not (system.power_user or user):
+            logger.warning("power-user is missing")
+        if not (system.power_pass or password) and not system.power_identity_file:
+            logger.warning("neither power-identity-file nor power-password specified")
+
+    def _get_power_input(self, system, power_operation, logger, user, password):
+        """
+        Creats an option string for the fence agent from the system data
+        Internal method
+
+        @param System system Cobbler system
+        @param str power_operation power operation. Valid values: on, off, status.
+                Rebooting is implemented as a set of 2 operations (off and on) in
+                a higher level method.
+        @param Logger logger logger
+        @param str user user to override system.power_user
+        @param str password password to override system.power_pass
+        """
+
+        self._check_power_conf(system, logger, user, password)
+        power_input = ""
+        if power_operation is None or power_operation not in ['on', 'off', 'status']:
+            raise CX("invalid power operation")
+        power_input += "action=" + power_operation + "\n"
+        if system.power_address:
+            power_input += "ip=" + system.power_address + "\n"
+        if system.power_user:
+            power_input += "username=" + system.power_user + "\n"
+        if system.power_id:
+            power_input += "plug=" + system.power_id + "\n"
+        if system.power_pass:
+            power_input += "password=" + system.power_pass + "\n"
+        if system.power_identity_file:
+            power_input += "identity-file=" + system.power_identity_file + "\n"
+        if system.power_options:
+            power_input += system.power_options + "\n"
+        return power_input
+
     def _power(self, system, power_operation, user=None, password=None, logger=None):
         """
         Performs a power operation on a system.
@@ -137,34 +200,27 @@ class PowerManager(object):
         meta = utils.blender(self.api, False, system)
         meta["power_mode"] = power_operation
 
-        # allow command line overrides of the username/password
-        if user is not None:
-            meta["power_user"] = user
-        if password is not None:
-            meta["power_pass"] = password
-
         logger.info("cobbler power configuration is:")
         logger.info("      type   : %s" % system.power_type)
         logger.info("      address: %s" % system.power_address)
         logger.info("      user   : %s" % system.power_user)
         logger.info("      id     : %s" % system.power_id)
+        logger.info("      options: %s" % system.power_options)
+        logger.info("identity_file: %s" % system.power_identity_file)
 
         # if no username/password data, check the environment
-        if meta.get("power_user", "") == "":
-            meta["power_user"] = os.environ.get("COBBLER_POWER_USER", "")
-        if meta.get("power_pass", "") == "":
-            meta["power_pass"] = os.environ.get("COBBLER_POWER_PASS", "")
+        if not system.power_user and not user:
+            user = os.environ.get("COBBLER_POWER_USER", "")
+        if not system.power_pass and not password:
+            password = os.environ.get("COBBLER_POWER_PASS", "")
 
-        template = self.get_power_template(system.power_type)
-        tmp = templar.Templar(self.collection_mgr)
-        template_data = tmp.render(template, meta, None, system)
+        power_input = self._get_power_input(system, power_operation, logger, user, password)
+
         logger.info("power command: %s" % power_command)
-        logger.info("power command input: %s" % template_data)
+        logger.info("power command input: %s" % power_input)
 
-        # Try the power command 5 times before giving up.
-        # Some power switches are flakey
-        for x in range(0, 5):
-            output, rc = utils.subprocess_sp(logger, power_command, shell=False, input=template_data)
+        for x in range(0, POWER_RETRIES):
+            output, rc = utils.subprocess_sp(logger, power_command, shell=False, input=power_input)
             # fencing agent returns 2 if the system is powered off
             if rc == 0 or (rc == 2 and power_operation == 'status'):
                 # If the desired state is actually a query for the status
@@ -239,22 +295,3 @@ class PowerManager(object):
         """
 
         return self._power(system, "status", user, password, logger)
-
-    def get_power_template(self, power_type):
-        """
-        Get power management template
-
-        @param str power_type power management type
-        @return str power management input template
-        """
-
-        if power_type:
-            power_template = "%s/fence_%s.template" % (self.settings.power_template_dir, power_type)
-            if os.path.isfile(power_template):
-                f = open(power_template)
-                template = f.read()
-                f.close()
-                return template
-
-        # return a generic template if a specific one wasn't found
-        return "action=$power_mode\nlogin=$power_user\npasswd=$power_pass\nipaddr=$power_address\nport=$power_id"

--- a/templates/power/fence_apc_snmp.template
+++ b/templates/power/fence_apc_snmp.template
@@ -1,3 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-port=$power_id

--- a/templates/power/fence_bladecenter.template
+++ b/templates/power/fence_bladecenter.template
@@ -1,6 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass
-port=$power_id
-secure

--- a/templates/power/fence_bullpap.template
+++ b/templates/power/fence_bullpap.template
@@ -1,5 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass
-port=$power_id

--- a/templates/power/fence_drac.template
+++ b/templates/power/fence_drac.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass

--- a/templates/power/fence_ilo.template
+++ b/templates/power/fence_ilo.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass

--- a/templates/power/fence_ipmilan.template
+++ b/templates/power/fence_ipmilan.template
@@ -1,5 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass
-$power_id

--- a/templates/power/fence_lpar.template
+++ b/templates/power/fence_lpar.template
@@ -1,9 +1,0 @@
-#set ($power_sys, $power_lpar) = $power_id.split(':')
-
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-managed=$power_sys
-port=$power_lpar
-passwd=$power_pass
-secure

--- a/templates/power/fence_rsa.template
+++ b/templates/power/fence_rsa.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass

--- a/templates/power/fence_virsh.template
+++ b/templates/power/fence_virsh.template
@@ -1,5 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass
-port=$power_id

--- a/templates/power/fence_wti.template
+++ b/templates/power/fence_wti.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-passwd=$power_pass
-port=$power_id


### PR DESCRIPTION
The former, template based solution was rather ungeneric/fixed.
For every fence a cobbler fence config mapping in /etc/cobbler/power/fence_*
was needed.

This patch allows the use of identity-file fence option which allows
passwordless ssh connections via ssh keys.

It also uses the new fence_* stdin paramters which have been adopted
to the command paramters.
See manpage of fence agents, e.g.:
username
         Login name This parameter is always required. Obsoletes: login

Via power-options field any fence parameter can now be passed.
Theoretically username, password, address, etc. can all be passed via:
POWER_OPTIONS <<< "username=admin
ip=xy.domain.com"

--power-options="$POWER_OPTIONS"