### PR TITLE
Security: Fix CVE-2022-0860

### DIFF
--- a/cobbler/modules/authentication/pam.py
+++ b/cobbler/modules/authentication/pam.py
@@ -108,6 +108,10 @@ PAM_AUTHENTICATE = LIBPAM.pam_authenticate
 PAM_AUTHENTICATE.restype = c_int
 PAM_AUTHENTICATE.argtypes = [PamHandle, c_int]
 
+PAM_ACCT_MGMT = LIBPAM.pam_acct_mgmt
+PAM_ACCT_MGMT.restype = c_int
+PAM_ACCT_MGMT.argtypes = [PamHandle, c_int]
+
 
 def authenticate(api_handle, username, password):
     """
@@ -147,4 +151,8 @@ def authenticate(api_handle, username, password):
         return False
 
     retval = PAM_AUTHENTICATE(handle, 0)
+
+    if retval == 0:
+        retval = PAM_ACCT_MGMT(handle, 0)
+
     return retval == 0

--- a/tests/special_cases/security_test.py
+++ b/tests/special_cases/security_test.py
@@ -1,0 +1,39 @@
+"""
+This test module tries to automatically replicate all security incidents we had in the past and checks if they fail.
+"""
+# SPDX-License-Identifier: GPL-2.0-or-later
+import base64
+import crypt
+import logging
+import os
+import subprocess
+import xmlrpc.client
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.modules.authentication import pam
+
+
+# ==================== START ysf ====================
+
+# SPDX-FileCopyrightText: 2022 ysf <nicolas.chatelain@tnpconsultants.com>
+
+
+def test_pam_login_with_expired_user():
+    # Arrange
+    test_api = CobblerAPI()
+    test_username = "expired_user"
+    test_password = "password"
+    # create pam testuser
+    subprocess.run(["useradd", "-p", crypt.crypt(test_password), test_username])
+    # change user to be expired
+    subprocess.run(["chage", "-E0", test_username])
+
+    # Act - Try login
+    result = pam.authenticate(test_api, test_username, test_password)
+
+    # Assert - Login failed
+    assert not result
+
+# ==================== END ysf ====================


### PR DESCRIPTION
## Linked Items

Fixes https://github.com/SUSE/spacewalk/issues/20411

## Description

If PAM is correctly configured and a user account is set to expired, the expired user-account is still able to successfully log into Cobbler in all places (Web UI, CLI & XMLRPC-API).

The same applies to user accounts with passwords set to be expired.

This patch is fixing this and checking that this behavior is now correct via a reproducible test.

## Behaviour changes

Old: PAM was vulnerable

New: PAM is fixed.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 