### PR TITLE
SUMA 4.3: Fixup specfile for building RPMs

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -1,6 +1,7 @@
 #
 # spec file for package cobbler
 #
+# Copyright (c) 2023 SUSE LLC
 # Copyright (c) 2006 Michael DeHaan <mdehaan@redhat.com>
 #
 # All modifications and additions to the file contributed by third parties
@@ -21,6 +22,7 @@
 # - Ubuntu: 18.04
 #
 # If it doesn't build on the Open Build Service (OBS) it's a bug.
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
 # Force bash instead of Debian dash

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -278,6 +278,13 @@ Requires:       cobbler = %{version}-%{release}
 %description tests
 Unit test files from the Cobbler project
 
+%package tests-containers
+Summary:        Dockerfiles and scripts to setup testing containers
+Requires:       cobbler = %{version}-%{release}
+
+%description tests-containers
+Dockerfiles and scripts to setup testing containers
+
 
 %prep
 %setup
@@ -479,6 +486,10 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %files tests
 %dir %{_datadir}/cobbler/tests
 %{_datadir}/cobbler/tests/*
+
+%files tests-containers
+%dir %{_datadir}/cobbler/docker
+%{_datadir}/cobbler/docker/*
 
 %changelog
 * Thu Dec 19 2019 Neal Gompa <ngompa13@gmail.com>


### PR DESCRIPTION
## Linked Items

Fixes <https://github.com/SUSE/spacewalk/issues/20340>

## Description

Fixes the missing SPEC backports.

## Behaviour changes

Old: Cobbler cannot be built successfully to an RPM.

New: Cobbler builds again.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
