### PR TITLE
suma/4.3: Add missing import to conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
+from cobbler.items.image import Image
 from cobbler.items.system import NetworkInterface, System
 
 


### PR DESCRIPTION
This PR adds a missing import to `conftest.py` that was somehow wrongly excluded when applying https://github.com/openSUSE/cobbler/commit/3bf323afc27af2378a00d7dba3740a52377e7e90