### PR TITLE
suma/head: Add missing import to conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
+from cobbler.items.image import Image
 from cobbler.items.system import NetworkInterface, System
 
 


### PR DESCRIPTION
Backport https://github.com/openSUSE/cobbler/pull/22 to `suma/head`.