### PR TITLE
4.2: Fixup to expected SUSE TFTP Server location

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -130,7 +130,7 @@ DEFAULTS = {
     "sign_puppet_certs_automatically": [0, "bool"],
     "signature_path": ["/var/lib/cobbler/distro_signatures.json", "str"],
     "signature_url": ["https://cobbler.github.io/signatures/3.0.x/latest.json", "str"],
-    "tftpboot_location": ["/var/lib/tftpboot", "str"],
+    "tftpboot_location": ["/srv/tftpboot", "str"],
     "virt_auto_boot": [0, "bool"],
     "webdir": ["/var/www/cobbler", "str"],
     "webdir_whitelist": [".link_cache", "misc", "distro_mirror", "images", "links", "localmirror", "pub", "rendered", "repo_mirror", "repo_profile", "repo_system", "svc", "web", "webui"],

--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -246,8 +246,8 @@ manage_tftpd: 1
 
 # This variable contains the location of the tftpboot directory. If this directory is not present cobbler does not
 # start.
-# Default: /var/lib/tftpboot
-tftpboot_location: "/var/lib/tftpboot"
+# Default: /srv/tftpboot
+tftpboot_location: "/srv/tftpboot"
 
 # set to 1 to enable Cobbler's RSYNC management features.
 manage_rsync: 0


### PR DESCRIPTION
## Linked Items

Fixes 

## Description

Fix an issue that changes the TFTP directory to the wrong default.

## Behaviour changes

Old: Cobbler wouldn't find the SUSE TFTP server directory.

New: Cobbler finds the TFTP server directory on SLE.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
