### PR TITLE
Fix buildiso with efi firmware

### DIFF
--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -224,6 +224,7 @@ Requires:       %{createrepo_pkg}
 Requires:       fence-agents
 Requires:       rsync
 Requires:       xorriso
+Requires:       dosfstools
 %{?python_enable_dependency_generator}
 %if ! (%{defined python_enable_dependency_generator} || %{defined python_disable_dependency_generator})
 Requires:       %{py3_module_cheetah}
@@ -423,6 +424,7 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %dir %{_sysconfdir}/cobbler/iso
 %config(noreplace) %{_sysconfdir}/cobbler/iso/buildiso.template
 %config(noreplace) %{_sysconfdir}/cobbler/iso/isolinux_menuentry.template
+%config(noreplace) %{_sysconfdir}/cobbler/iso/grub_menuentry.template
 %config(noreplace) %{_sysconfdir}/cobbler/logging_config.conf
 %attr(640, root, root) %config(noreplace) %{_sysconfdir}/cobbler/modules.conf
 %attr(600, root, root) %config(noreplace) %{_sysconfdir}/cobbler/mongodb.conf

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -422,6 +422,7 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %config(noreplace) %{_sysconfdir}/cobbler/import_rsync_whitelist
 %dir %{_sysconfdir}/cobbler/iso
 %config(noreplace) %{_sysconfdir}/cobbler/iso/buildiso.template
+%config(noreplace) %{_sysconfdir}/cobbler/iso/isolinux_menuentry.template
 %config(noreplace) %{_sysconfdir}/cobbler/logging_config.conf
 %attr(640, root, root) %config(noreplace) %{_sysconfdir}/cobbler/modules.conf
 %attr(600, root, root) %config(noreplace) %{_sysconfdir}/cobbler/mongodb.conf

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -7,7 +7,9 @@ memory.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
+import contextlib
 import logging
+import re
 import os
 import pathlib
 import shutil
@@ -48,12 +50,14 @@ class BootFilesCopyset(NamedTuple):
 
 class LoaderCfgsParts(NamedTuple):
     isolinux: List[str]
+    grub: List[str]
     bootfiles_copysets: List[BootFilesCopyset]
 
 
 class BuildisoDirs(NamedTuple):
     root: pathlib.Path
     isolinux: pathlib.Path
+    grub: pathlib.Path
     autoinstall: pathlib.Path
     repo: pathlib.Path
 
@@ -79,6 +83,13 @@ class BuildIso:
         self.templar = templar.Templar(api)
         self.isolinuxdir = ""
 
+        # based on https://uefi.org/sites/default/files/resources/UEFI%20Spec%202.8B%20May%202020.pdf
+        # FIXME: PowerPC is missing from the table
+        self.efi_fallback_renames = {
+            "grubaa64": "bootaa64.efi",
+            "grubx86.efi": "bootx64.efi",
+        }
+
         # grab the header from buildiso.header file
         self.iso_template = (
             pathlib.Path(self.api.settings().iso_template_dir)
@@ -90,6 +101,38 @@ class BuildIso:
             .joinpath("isolinux_menuentry.template")
             .read_text(encoding="UTF-8")
         )
+        self.grub_menuentry_template = (
+            pathlib.Path(api.settings().iso_template_dir)
+            .joinpath("grub_menuentry.template")
+            .read_text(encoding="UTF-8")
+        )
+
+    def _find_distro_source(self, known_file: str, distro_mirror: str) -> str:
+        """
+        Find a distro source tree based on a known file.
+
+        :param known_file: Path to a file that's known to be part of the distribution,
+            commonly the path to the kernel.
+        :raises ValueError: When no installation source was not found.
+        :return: Root of the distribution's source tree.
+        """
+        self.logger.debug("Trying to locate source.")
+        (source_head, source_tail) = os.path.split(known_file)
+        filesource = None
+        while source_tail != "":
+            if source_head == distro_mirror:
+                filesource = os.path.join(source_head, source_tail)
+                self.logger.debug("Found source in %s", filesource)
+                break
+            (source_head, source_tail) = os.path.split(source_head)
+
+        if filesource:
+            return filesource
+        else:
+            raise ValueError(
+                "No installation source found. When building a standalone (incl. airgapped) ISO"
+                " you must specify a --source if the distro install tree is not hosted locally"
+            )
 
     def _copy_boot_files(
         self, kernel_path, initrd_path, destdir: str, new_filename: str = ""
@@ -230,6 +273,20 @@ class BuildIso:
                 "Required file(s) not found. Please check your syslinux installation"
             )
 
+    def _render_grub_entry(
+        self, append_line, menu_name, kernel_path, initrd_path
+    ) -> str:
+        return self.templar.render(
+            self.grub_menuentry_template,
+            out_path=None,
+            search_table={
+                "menu_name": menu_name,
+                "kernel_path": kernel_path,
+                "initrd_path": initrd_path,
+                "kernel_options": re.sub(r".*initrd=\S+", "", append_line),
+            },
+        )
+
     def _render_isolinux_entry(
         self, append_line: str, menu_name: str, kernel_path: str, menu_indent: int = 0
     ) -> str:
@@ -246,7 +303,17 @@ class BuildIso:
             template_type="jinja2",
         )
 
-    def calculate_grub_name(self, distro) -> str:
+    def _copy_grub_into_esp(self, esp_image_location: str, arch: Archs):
+        grub_name = self.calculate_grub_name(arch)
+        efi_name = self.efi_fallback_renames.get(grub_name, grub_name)
+        with self._mount_esp(esp_image_location) as mountpoint:
+            esp_efi_boot = self._create_efi_boot_dir(mountpoint)
+            grub_binary = (
+                pathlib.Path(self.api.settings().bootloaders_dir) / "grub" / grub_name
+            )
+            utils.copyfile(str(grub_binary), f"{esp_efi_boot}/{efi_name}")
+
+    def calculate_grub_name(self, desired_arch: Archs) -> str:
         """
         This function checks the bootloaders_formats in our settings and then checks if there is a match between the
         architectures and the distribution architecture.
@@ -254,7 +321,6 @@ class BuildIso:
         """
         loader_formats = self.api.settings().bootloaders_formats
         grub_binary_names: Dict[str, str] = {}
-        desired_arch = distro.arch
 
         for (loader_format, values) in loader_formats.items():
             name = values.get("binary_name", None)
@@ -304,6 +370,74 @@ class BuildIso:
         with open(output_file, "w") as f:
             f.write("\n".join(cfg_parts))
 
+    def _write_grub_cfg(self, cfg_parts: List[str], output_dir: pathlib.Path) -> None:
+        """Write grub.cfg.
+
+        :param cfg_parts: List of str that is written to the config, joined by newlines.
+        :param output_dir: pathlib.Path that the grub.cfg file is written into.
+        """
+        output_file = output_dir / "grub.cfg"
+        self.logger.info("Writing %s", output_file)
+        with open(output_file, "w") as f:
+            f.write("\n".join(cfg_parts))
+
+    def _create_esp_image_file(self, tmpdir: str) -> str:
+        esp = pathlib.Path(tmpdir) / "efi"
+        mkfs_cmd = ["mkfs.fat", "-C", str(esp), "3528"]
+        rc = utils.subprocess_call(mkfs_cmd, shell=False)
+        if rc != 0:
+            self.logger.error("Could not create ESP image file")
+            raise Exception  # TODO: use proper exception
+        return str(esp)
+
+    @contextlib.contextmanager
+    def _mount_esp(self, esp_path: str):
+        def mount(esp_path: str, mountpoint: pathlib.Path) -> None:
+            mp.mkdir()
+
+            mount_cmd = ["mount", "-o", "loop", esp_path, mountpoint]
+            rc = utils.subprocess_call(mount_cmd, shell=False)
+            if rc != 0:
+                self.logger.error(
+                    "Could not mount ESP image file %s at %s", esp_path, mountpoint
+                )
+                raise Exception  # TODO: use concrete exception
+
+        def umount(mountpoint: pathlib.Path) -> None:
+            unmount_cmd = ["umount", mountpoint]
+            rc = utils.subprocess_call(unmount_cmd, shell=False)
+            if rc != 0:
+                self.logger.error("Could not unmount ESP image file at %s", mountpoint)
+                raise Exception  # TODO: use concrete exception
+            mountpoint.rmdir()
+
+        mp = pathlib.Path(esp_path + "_mounted")
+        try:
+            mount(esp_path, mp)
+            yield str(mp)
+        finally:
+            umount(mp)
+
+    def _create_efi_boot_dir(self, esp_mountpoint: str) -> str:
+        efi_boot = pathlib.Path(esp_mountpoint) / "EFI" / "BOOT"
+        self.logger.info("Creating %s", efi_boot)
+        efi_boot.mkdir(parents=True)
+        return str(efi_boot)
+
+    def _find_esp(self, root_dir: pathlib.Path) -> Optional[str]:
+        """Walk root directory and look for an ESP."""
+        candidates = [str(match) for match in root_dir.glob("**/efi")]
+        if len(candidates) == 0:
+            return None
+        elif len(candidates) == 1:
+            return candidates[0]
+        else:
+            self.logger.info(
+                "Found multiple ESP (%s), choosing %s", candidates, candidates[0]
+            )
+            return candidates[0]
+
+
     def _prepare_buildisodir(self, buildisodir: str = "") -> str:
         """
         This validated the path and type of the buildiso directory and then (re-)creates the apropiate directories.
@@ -337,24 +471,27 @@ class BuildIso:
         """Create directories in the buildiso root."""
         root = pathlib.Path(buildiso_root)
         isolinuxdir = root / "isolinux"
+        grubdir = root / "EFI" / "BOOT"
         autoinstalldir = root / "autoinstall"
         repodir = root / "repo_mirror"
-        for d in [isolinuxdir, autoinstalldir, repodir]:
+        for d in [isolinuxdir, grubdir, autoinstalldir, repodir]:
             d.mkdir(parents=True)
 
         return BuildisoDirs(
             root=root,
             isolinux=isolinuxdir,
+            grub=grubdir,
             autoinstall=autoinstalldir,
             repo=repodir,
         )
 
-    def _generate_iso(self, xorrisofs_opts: str, iso: str, buildisodir: str):
+    def _generate_iso(self, xorrisofs_opts: str, iso: str, buildisodir: str, esp_path: str):
         """
         Build the final xorrisofs command which is then executed on the disk.
         :param xorrisofs_opts: The additional options for xorrisofs.
         :param iso: The name of the output iso.
         :param buildisodir: The directory in which we build the ISO.
+        :param esp_path: The absolute path to the EFI system partition.
         """
         running_on, _ = utils.os_release()
         if running_on in ("suse", "centos", "virtuozzo", "redhat"):
@@ -365,7 +502,7 @@ class BuildIso:
             isohdpfx_location = pathlib.Path(self.api.settings().syslinux_dir).joinpath(
                 "mbr/isohdpfx.bin"
             )
-        efi_img_location = "grub/grub.efi"
+        esp_relative_path = pathlib.Path(esp_path).relative_to(buildisodir)
         cmd_list = [
             "xorriso",
             "-as",
@@ -383,7 +520,7 @@ class BuildIso:
             "-boot-info-table",
             "-eltorito-alt-boot",
             "-e",
-            efi_img_location,
+            str(esp_relative_path),
             "-no-emul-boot",
             "-isohybrid-gpt-basdat",
             "-V",

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -554,6 +554,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         distro_name: str = "",
         systems: List[str] = None,
         exclude_dns: bool = False,
+        **kwargs,
     ):
         """
         Run the whole iso generation from bottom to top. Per default this builds an ISO for all available systems
@@ -569,6 +570,8 @@ class NetbootBuildiso(buildiso.BuildIso):
                         systems.
         :param exclude_dns: Whether the repositories have to be locally available or the internet is reachable.
         """
+        del kwargs  # just accepted for polymorphism
+
         buildisodir = self._prepare_iso(buildisodir, distro_name, profiles)
         systems = utils.input_string_or_list_no_inherit(systems)
         self.generate_netboot_iso(systems, exclude_dns)

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -4,6 +4,7 @@ This module contains the specific code to generate a network bootable ISO.
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+import pathlib
 import re
 from typing import List, Optional, Tuple
 
@@ -347,7 +348,7 @@ class AppendLineBuilder:
         """
         self.dist = dist
 
-        self.append_line = "  APPEND initrd=%s.img" % self.distro_name
+        self.append_line = f"  APPEND initrd=/{self.distro_name}.img"
         if self.dist.breed == "suse":
             self._generate_append_suse()
         elif self.dist.breed == "redhat":
@@ -376,7 +377,7 @@ class AppendLineBuilder:
         :param distro_breed: The name of the distribution breed.
         :return: The generated append line.
         """
-        self.append_line = "  APPEND initrd=%s.img" % self.distro_name
+        self.append_line = f"  APPEND initrd=/{self.distro_name}.img"
         if distro_breed == "suse":
             if self.data.get("proxy", "") != "":
                 self.append_line += " proxy=%s" % self.data["proxy"]
@@ -468,24 +469,16 @@ class NetbootBuildiso(buildiso.BuildIso):
         :param system_names: System filter, can be an empty list for "all systems".
         :param exclude_dns: Used for system kernel cmdline.
         """
-        isolinux_cfg_parts, files_to_copy = [self.iso_template], []
-        isolinux_cfg_parts.append("MENU SEPARATOR")
-        self._generate_profiles_loader_configs(
-            profile_names, isolinux_cfg_parts, files_to_copy
-        )
+        loader_config_parts = LoaderCfgsParts([self.iso_template], [], [])
+        loader_config_parts.isolinux.append("MENU SEPARATOR")
+        self._generate_profiles_loader_configs(profile_names, loader_config_parts)
         self._generate_systems_loader_configs(
-            system_names, exclude_dns, isolinux_cfg_parts, files_to_copy
+            system_names, exclude_dns, loader_config_parts
         )
-        return LoaderCfgsParts(
-            isolinux=isolinux_cfg_parts,
-            bootfiles_copysets=files_to_copy,
-        )
+        return loader_config_parts
 
     def _generate_profiles_loader_configs(
-        self,
-        profiles: List[str],
-        isolinux_cfg_parts: List[str],
-        bootfiles_copyset: List[BootFilesCopyset],
+        self, profiles: List[str], loader_cfg_parts: LoaderCfgsParts
     ) -> None:
         """Generate isolinux configuration for profiles.
 
@@ -496,11 +489,12 @@ class NetbootBuildiso(buildiso.BuildIso):
         :param bootfiles_copyset: Output parameter for bootfiles copyset.
         """
         for profile in self.filter_profiles(profiles):
-            isolinux, to_copy = self._generate_profile_config(profile)
-            isolinux_cfg_parts.append(isolinux)
-            bootfiles_copyset.append(to_copy)
+            isolinux, grub, to_copy = self._generate_profile_config(profile)
+            loader_cfg_parts.isolinux.append(isolinux)
+            loader_cfg_parts.grub.append(grub)
+            loader_cfg_parts.bootfiles_copysets.append(to_copy)
 
-    def _generate_profile_config(self, profile) -> Tuple[str, BootFilesCopyset]:
+    def _generate_profile_config(self, profile) -> Tuple[str, str, BootFilesCopyset]:
         """Generate isolinux configuration for a single profile.
 
         :param profile: Profile object to generate the configuration for.
@@ -524,12 +518,20 @@ class NetbootBuildiso(buildiso.BuildIso):
             distro_name=distroname, data=data
         ).generate_profile(distro.breed)
         kernel_path = f"/{distroname}.krn"
+        initrd_path = f"/{distroname}.img"
 
         isolinux_cfg = self._render_isolinux_entry(
             append_line, menu_name=profile.name, kernel_path=kernel_path
         )
+        grub_cfg = self._render_grub_entry(
+            append_line,
+            menu_name=profile.name,
+            kernel_path=kernel_path,
+            initrd_path=initrd_path,
+        )
         return (
             isolinux_cfg,
+            grub_cfg,
             BootFilesCopyset(distro.kernel, distro.initrd, distroname),
         )
 
@@ -537,8 +539,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         self,
         system_names: List[str],
         exclude_dns: bool,
-        isolinux_cfg_parts: List[str],
-        files_to_copy: List[BootFilesCopyset],
+        loader_cfg_parts: LoaderCfgsParts,
     ) -> None:
         """Generate isolinux configuration for systems.
 
@@ -549,15 +550,16 @@ class NetbootBuildiso(buildiso.BuildIso):
         :param bootfiles_copyset: Output parameter for bootfiles copyset.
         """
         for system in self.filter_systems(system_names):
-            isolinux, to_copy = self._generate_system_config(
+            isolinux, grub, to_copy = self._generate_system_config(
                 system, exclude_dns=exclude_dns
             )
-            isolinux_cfg_parts.append(isolinux)
-            files_to_copy.append(to_copy)
+            loader_cfg_parts.isolinux.append(isolinux)
+            loader_cfg_parts.grub.append(grub)
+            loader_cfg_parts.bootfiles_copysets.append(to_copy)
 
     def _generate_system_config(
         self, system, exclude_dns
-    ) -> Tuple[str, BootFilesCopyset]:
+    ) -> Tuple[str, str, BootFilesCopyset]:
         """Generate isolinux configuration for a single system.
 
         :param system: System object to generate the configuration for.
@@ -579,16 +581,29 @@ class NetbootBuildiso(buildiso.BuildIso):
         append_line = AppendLineBuilder(
             distro_name=distroname, data=data
         ).generate_system(distro, system, exclude_dns)
-        kernel_path = distroname + ".krn"
+        kernel_path = f"/{distroname}.krn"
+        initrd_path = f"/{distroname}.img"
 
         isolinux_cfg = self._render_isolinux_entry(
             append_line, menu_name=system.name, kernel_path=kernel_path
         )
+        grub_cfg = self._render_grub_entry(
+            append_line,
+            menu_name=system.name,
+            kernel_path=kernel_path,
+            initrd_path=initrd_path,
+        )
 
         return (
             isolinux_cfg,
+            grub_cfg,
             BootFilesCopyset(distro.kernel, distro.initrd, distroname),
         )
+
+    def _copy_esp(self, esp_source: str, buildisodir: str):
+        """Copy existing EFI System Partition into the buildisodir."""
+        utils.copyfile(esp_source, buildisodir + "/efi")
+
 
     def run(
         self,
@@ -619,7 +634,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         """
         del kwargs  # just accepted for polymorphism
 
-        _ = self.parse_distro(distro_name)
+        distro_obj = self.parse_distro(distro_name)
         system_names = utils.input_string_or_list_no_inherit(systems)
         profile_names = utils.input_string_or_list_no_inherit(profiles)
         loader_config_parts = self._generate_boot_loader_configs(
@@ -627,7 +642,8 @@ class NetbootBuildiso(buildiso.BuildIso):
         )
 
         buildisodir = self._prepare_buildisodir(buildisodir)
-        dirs = self.create_buildiso_dirs(buildisodir)
+        buildiso_dirs = self.create_buildiso_dirs(buildisodir)
+        distro_mirrordir = pathlib.Path(self.api.settings().webdir) / "distro_mirror"
 
         # fill temporary directory with binaries
         self._copy_isolinux_files()
@@ -635,12 +651,26 @@ class NetbootBuildiso(buildiso.BuildIso):
             self._copy_boot_files(
                 copyset.src_kernel,
                 copyset.src_initrd,
-                str(buildisodir),
+                str(buildiso_dirs.root),
                 copyset.new_filename,
             )
 
-        # fill temporary directory with config files
-        self._write_isolinux_cfg(loader_config_parts.isolinux, dirs.isolinux)
+        try:
+            filesource = self._find_distro_source(
+                distro_obj.kernel, str(distro_mirrordir)
+            )
+            self.logger.info("filesource=%s", filesource)
+            distro_esp = self._find_esp(pathlib.Path(filesource))
+            self.logger.info("esp=%s", distro_esp)
+        except ValueError:
+            distro_esp = None
 
-        # build ISO off the temporary directory
-        self._generate_iso(xorrisofs_opts, iso, buildisodir)
+        if distro_esp is not None:
+            self._copy_esp(distro_esp, buildisodir)
+        else:
+            esp_location = self._create_esp_image_file(buildisodir)
+            self._copy_grub_into_esp(esp_location, distro_obj.arch)
+
+        self._write_isolinux_cfg(loader_config_parts.isolinux, buildiso_dirs.isolinux)
+        self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)
+        self._generate_iso(xorrisofs_opts, iso, buildisodir, buildisodir + "/efi")

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -4,12 +4,12 @@ This module contains the specific code to generate a network bootable ISO.
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-import os
 import re
-from typing import List
+from typing import List, Optional, Tuple
 
 from cobbler import utils
 from cobbler.actions import buildiso
+from cobbler.actions.buildiso import BootFilesCopyset, LoaderCfgsParts
 
 
 class AppendLineBuilder:
@@ -425,6 +425,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         """
         Return a list of valid system objects selected from all systems by name, or everything if ``selected_items`` is
         empty.
+
         :param selected_items: A list of names to include in the returned list.
         :return: A list of valid systems. If an error occurred this is logged and an empty list is returned.
         """
@@ -444,6 +445,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         """
         Return a short distro identifier which is basically an internal counter which is mapped via the real distro
         name.
+
         :param distname: The distro name to return an identifier for.
         :return: A short distro identifier
         """
@@ -454,58 +456,61 @@ class NetbootBuildiso(buildiso.BuildIso):
         self.distmap[distname] = str(self.distctr)
         return str(self.distctr)
 
-    def _generate_netboot_system(self, system, cfglines: List[str], exclude_dns: bool):
+    def _generate_boot_loader_configs(
+        self, profile_names: List[str], system_names: List[str], exclude_dns: bool
+    ) -> LoaderCfgsParts:
+        """Generate boot loader configuration.
+
+        The configuration is placed as parts into a list. The elements expect to
+        be joined by newlines for writing.
+
+        :param profile_names: Profile filter, can be an empty list for "all profiles".
+        :param system_names: System filter, can be an empty list for "all systems".
+        :param exclude_dns: Used for system kernel cmdline.
         """
-        Generates the ISOLINUX cfg configuration for any systems included in the image.
-        :param system: The system which the configuration should be generated for.
-        :param cfglines: The already existing lines of the configuration.
-        :param exclude_dns: If DNS configuration should be excluded or not.
+        isolinux_cfg_parts, files_to_copy = [self.iso_template], []
+        isolinux_cfg_parts.append("MENU SEPARATOR")
+        self._generate_profiles_loader_configs(
+            profile_names, isolinux_cfg_parts, files_to_copy
+        )
+        self._generate_systems_loader_configs(
+            system_names, exclude_dns, isolinux_cfg_parts, files_to_copy
+        )
+        return LoaderCfgsParts(
+            isolinux=isolinux_cfg_parts,
+            bootfiles_copysets=files_to_copy,
+        )
+
+    def _generate_profiles_loader_configs(
+        self,
+        profiles: List[str],
+        isolinux_cfg_parts: List[str],
+        bootfiles_copyset: List[BootFilesCopyset],
+    ) -> None:
+        """Generate isolinux configuration for profiles.
+
+        The passed in isolinux_cfg_parts list is changed in-place.
+
+        :param profiles: Profile filter, can be empty for "all profiles".
+        :param isolinux_cfg_parts: Output parameter for isolinux configuration.
+        :param bootfiles_copyset: Output parameter for bootfiles copyset.
         """
-        self.logger.info("processing system: %s", system.name)
-        profile = system.get_conceptual_parent()
-        dist = profile.get_conceptual_parent()
-        distname = self.make_shorter(dist.name)
-        self.copy_boot_files(dist, self.isolinuxdir, distname)
+        for profile in self.filter_profiles(profiles):
+            isolinux, to_copy = self._generate_profile_config(profile)
+            isolinux_cfg_parts.append(isolinux)
+            bootfiles_copyset.append(to_copy)
 
-        cfglines.append("")
-        cfglines.append("LABEL %s" % system.name)
-        cfglines.append("  MENU LABEL %s" % system.name)
-        cfglines.append("  KERNEL %s.krn" % distname)
+    def _generate_profile_config(self, profile) -> Tuple[str, BootFilesCopyset]:
+        """Generate isolinux configuration for a single profile.
 
-        data = utils.blender(self.api, False, system)
-        if not re.match(r"[a-z]+://.*", data["autoinstall"]):
-            data["autoinstall"] = "http://%s:%s/cblr/svc/op/autoinstall/system/%s" % (
-                data["server"],
-                data["http_port"],
-                system.name,
-            )
-
-        append_builder = AppendLineBuilder(distro_name=distname, data=data)
-        append_line = append_builder.generate_system(dist, system, exclude_dns)
-        cfglines.append(append_line)
-
-    def _generate_netboot_profile(self, profile, cfglines: List[str]):
+        :param profile: Profile object to generate the configuration for.
         """
-        Generates the ISOLINUX cfg configuration for any profiles included in the image.
-        :param profile: The profile which the configuration should be generated for.
-        :param cfglines: The already existing lines of the configuration.
-        """
-        self.logger.info('Processing profile: "%s"', profile.name)
-        dist = profile.get_conceptual_parent()
-        distname = self.make_shorter(dist.name)
-        self.copy_boot_files(dist, self.isolinuxdir, distname)
-
-        cfglines.append("")
-        cfglines.append("LABEL %s" % profile.name)
-        cfglines.append("  MENU LABEL %s" % profile.name)
-        cfglines.append("  kernel %s.krn" % distname)
-
-        data = utils.blender(self.api, False, profile)
-
-        # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-        if dist is not None:
+        distro = profile.get_conceptual_parent()
+        distroname = self.make_shorter(distro.name)
+        data = utils.blender(self.api, False, distro)
+        if distro is not None:  # SUSE uses 'textmode' instead of 'text'
             utils.kopts_overwrite(
-                data["kernel_options"], self.api.settings().server, dist.breed
+                data["kernel_options"], self.api.settings().server, distro.breed
             )
 
         if not re.match(r"[a-z]+://.*", data["autoinstall"]):
@@ -515,35 +520,75 @@ class NetbootBuildiso(buildiso.BuildIso):
                 profile.name,
             )
 
-        append_builder = AppendLineBuilder(distro_name=distname, data=data)
-        append_line = append_builder.generate_profile(dist.breed)
-        cfglines.append(append_line)
+        append_line = AppendLineBuilder(
+            distro_name=distroname, data=data
+        ).generate_profile(distro.breed)
+        kernel_path = f"/{distroname}.krn"
 
-    def generate_netboot_iso(
-        self, systems: List[str] = None, exclude_dns: bool = False
-    ):
+        isolinux_cfg = self._render_isolinux_entry(
+            append_line, menu_name=profile.name, kernel_path=kernel_path
+        )
+        return (
+            isolinux_cfg,
+            BootFilesCopyset(distro.kernel, distro.initrd, distroname),
+        )
+
+    def _generate_systems_loader_configs(
+        self,
+        system_names: List[str],
+        exclude_dns: bool,
+        isolinux_cfg_parts: List[str],
+        files_to_copy: List[BootFilesCopyset],
+    ) -> None:
+        """Generate isolinux configuration for systems.
+
+        The passed in isolinux_cfg_parts list is changed in-place.
+
+        :param systems: System filter, can be empty for "all profiles".
+        :param isolinux_cfg_parts: Output parameter for isolinux configuration.
+        :param bootfiles_copyset: Output parameter for bootfiles copyset.
         """
-        Creates the ``isolinux.cfg`` for a network bootable ISO image.
-        :param systems: The filter to generate a netboot iso for. You may specify multiple systems on the CLI space
-                        separated.
-        :param exclude_dns: If this is True then the dns server is skipped. False will set it.
+        for system in self.filter_systems(system_names):
+            isolinux, to_copy = self._generate_system_config(
+                system, exclude_dns=exclude_dns
+            )
+            isolinux_cfg_parts.append(isolinux)
+            files_to_copy.append(to_copy)
+
+    def _generate_system_config(
+        self, system, exclude_dns
+    ) -> Tuple[str, BootFilesCopyset]:
+        """Generate isolinux configuration for a single system.
+
+        :param system: System object to generate the configuration for.
+        :exclude_dns: Control if DNS configuration is part of the kernel cmdline.
         """
-        # setup isolinux.cfg
-        isolinuxcfg = os.path.join(self.isolinuxdir, "isolinux.cfg")
-        cfglines = [self.iso_template]
+        profile = system.get_conceptual_parent()
+        distro = (
+            profile.get_conceptual_parent()
+        )  # FIXME: pass distro, it's known from CLI
+        distroname = self.make_shorter(distro.name)
 
-        # iterate through selected profiles
-        for profile in self.filter_profiles(self.profiles):
-            self._generate_netboot_profile(profile, cfglines)
-        cfglines.append("MENU SEPARATOR")
-        # iterate through all selected systems
-        for system in self.filter_systems(systems):
-            self._generate_netboot_system(system, cfglines, exclude_dns)
-        cfglines.append("")
-        cfglines.append("MENU END")
+        data = utils.blender(self.api, False, system)
+        if not re.match(r"[a-z]+://.*", data["autoinstall"]):
+            data["autoinstall"] = (
+                f"http://{data['server']}:{data['http_port']}/cblr/svc/op/autoinstall/"
+                f"system/{system.name}"
+            )
 
-        with open(isolinuxcfg, "w+") as cfg:
-            cfg.writelines("%s\n" % l for l in cfglines)
+        append_line = AppendLineBuilder(
+            distro_name=distroname, data=data
+        ).generate_system(distro, system, exclude_dns)
+        kernel_path = distroname + ".krn"
+
+        isolinux_cfg = self._render_isolinux_entry(
+            append_line, menu_name=system.name, kernel_path=kernel_path
+        )
+
+        return (
+            isolinux_cfg,
+            BootFilesCopyset(distro.kernel, distro.initrd, distroname),
+        )
 
     def run(
         self,
@@ -557,10 +602,12 @@ class NetbootBuildiso(buildiso.BuildIso):
         **kwargs,
     ):
         """
-        Run the whole iso generation from bottom to top. Per default this builds an ISO for all available systems
-        and profiles.
-        This is the only method which should be called from non-class members. The ``profiles`` and ``system``
-        parameters can be combined.
+        Generate a net-installer for a distribution.
+
+        By default, the ISO includes all available systems and profiles. Specify
+        ``profiles`` and ``systems`` to only include the selected systems and
+        profiles. Both parameters can be provided at the same time.
+
         :param iso: The name of the iso. Defaults to "autoinst.iso".
         :param buildisodir: This overwrites the directory from the settings in which the iso is built in.
         :param profiles: The filter to generate the ISO only for selected profiles.
@@ -572,7 +619,28 @@ class NetbootBuildiso(buildiso.BuildIso):
         """
         del kwargs  # just accepted for polymorphism
 
-        buildisodir = self._prepare_iso(buildisodir, distro_name, profiles)
-        systems = utils.input_string_or_list_no_inherit(systems)
-        self.generate_netboot_iso(systems, exclude_dns)
+        _ = self.parse_distro(distro_name)
+        system_names = utils.input_string_or_list_no_inherit(systems)
+        profile_names = utils.input_string_or_list_no_inherit(profiles)
+        loader_config_parts = self._generate_boot_loader_configs(
+            system_names, profile_names, exclude_dns
+        )
+
+        buildisodir = self._prepare_buildisodir(buildisodir)
+        dirs = self.create_buildiso_dirs(buildisodir)
+
+        # fill temporary directory with binaries
+        self._copy_isolinux_files()
+        for copyset in loader_config_parts.bootfiles_copysets:
+            self._copy_boot_files(
+                copyset.src_kernel,
+                copyset.src_initrd,
+                str(buildisodir),
+                copyset.new_filename,
+            )
+
+        # fill temporary directory with config files
+        self._write_isolinux_cfg(loader_config_parts.isolinux, dirs.isolinux)
+
+        # build ISO off the temporary directory
         self._generate_iso(xorrisofs_opts, iso, buildisodir)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -25,20 +25,20 @@ def _generate_append_line_standalone(data: dict, distro, descendant) -> str:
     :param descendant: The profile or system which is underneath the distro.
     :return: The base append_line which we need for booting the built ISO. Contains initrd and autoinstall parameter.
     """
-    append_line = "  APPEND initrd=%s" % os.path.basename(distro.initrd)
+    append_line = f"  APPEND initrd=/{os.path.basename(distro.initrd)}"
     if distro.breed == "redhat":
-        append_line += " inst.ks=cdrom:/isolinux/%s.cfg" % descendant.name
+        if distro.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+            append_line += f" ks=cdrom:/autoinstall/{descendant.name}.cfg"
+        else:
+            append_line += f" inst.ks=cdrom:/autoinstall/{descendant.name}.cfg"
     elif distro.breed == "suse":
         append_line += (
-            " autoyast=file:///isolinux/%s.cfg install=cdrom:///" % descendant.name
+            f" autoyast=file:///autoinstall/{descendant.name}.cfg install=cdrom:///"
         )
         if "install" in data["kernel_options"]:
             del data["kernel_options"]["install"]
     elif distro.breed in ["ubuntu", "debian"]:
-        append_line += (
-            " auto-install/enable=true preseed/file=/cdrom/isolinux/%s.cfg"
-            % descendant.name
-        )
+        append_line += f" auto-install/enable=true preseed/file=/cdrom/autoinstall/{descendant.name}.cfg"
 
     # add remaining kernel_options to append_line
     append_line += buildiso.add_remaining_kopts(data["kernel_options"])
@@ -49,33 +49,6 @@ class StandaloneBuildiso(buildiso.BuildIso):
     """
     This class contains all functionality related to building self-contained installation images.
     """
-
-    def _find_distro_source(self, known_file: str, distro_mirror: str) -> str:
-        """
-        Find a distro source tree based on a known file.
-
-        :param known_file: Path to a file that's known to be part of the distribution,
-            commonly the path to the kernel.
-        :raises ValueError: When no installation source was not found.
-        :return: Root of the distribution's source tree.
-        """
-        self.logger.debug("Trying to locate source.")
-        (source_head, source_tail) = os.path.split(known_file)
-        filesource = None
-        while source_tail != "":
-            if source_head == distro_mirror:
-                filesource = os.path.join(source_head, source_tail)
-                self.logger.debug("Found source in %s", filesource)
-                break
-            (source_head, source_tail) = os.path.split(source_head)
-
-        if filesource:
-            return filesource
-        else:
-            raise ValueError(
-                "No installation source found. When building a standalone (incl. airgapped) ISO"
-                " you must specify a --source if the distro install tree is not hosted locally"
-            )
 
     def _write_autoinstall_cfg(
         self, data: Dict[str, Autoinstall], output_dir: pathlib.Path
@@ -88,16 +61,24 @@ class StandaloneBuildiso(buildiso.BuildIso):
 
     def _generate_descendant_config(
         self, descendant, menu_indent: int, distro, append_line: str
-    ) -> Tuple[str, BootFilesCopyset]:
+    ) -> Tuple[str, str, BootFilesCopyset]:
         kernel_path = f"/{os.path.basename(distro.kernel)}"
+        initrd_path = f"/{os.path.basename(distro.initrd)}"
         isolinux_cfg = self._render_isolinux_entry(
             append_line,
             menu_name=descendant.name,
             kernel_path=kernel_path,
             menu_indent=menu_indent,
         )
+        grub_cfg = self._render_grub_entry(
+            append_line,
+            menu_name=descendant.name,
+            kernel_path=kernel_path,
+            initrd_path=initrd_path,
+        )
         return (
             isolinux_cfg,
+            grub_cfg,
             BootFilesCopyset(distro.kernel, distro.initrd, ""),
         )
 
@@ -151,7 +132,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         else:  # system
             config_args.update({"menu_indent": 4})
             autoinstall_args = {"system": descendant_obj}
-        isolinux, to_copy = self._generate_descendant_config(**config_args)
+        isolinux, grub, to_copy = self._generate_descendant_config(**config_args)
         autoinstall = self.api.autoinstallgen.generate_autoinstall(**autoinstall_args)
 
         if distro_obj.breed == "redhat":
@@ -170,6 +151,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
                 )
             autoinstall = self._update_repos_in_autoinstall_data(autoinstall, repos)
         cfg_parts.isolinux.append(isolinux)
+        cfg_parts.grub.append(grub)
         cfg_parts.bootfiles_copysets.append(to_copy)
         autoinstall_data[name] = Autoinstall(autoinstall, repos)
 
@@ -266,13 +248,14 @@ class StandaloneBuildiso(buildiso.BuildIso):
         distro_obj = self.parse_distro(distro_name)
         profile_objs = self.parse_profiles(profiles, distro_obj)
         filesource = source
-        loader_config_parts = LoaderCfgsParts([self.iso_template], [])
+        loader_config_parts = LoaderCfgsParts([self.iso_template], [], [])
         autoinstall_data: Dict[str, Autoinstall] = {}
         buildisodir = self._prepare_buildisodir(buildisodir)
         buildiso_dirs = self.create_buildiso_dirs(buildisodir)
         repo_mirrordir = pathlib.Path(self.api.settings().webdir) / "repo_mirror"
         distro_mirrordir = pathlib.Path(self.api.settings().webdir) / "distro_mirror"
 
+        # generate configs, list of repos, and autoinstall data
         for profile_obj in profile_objs:
             self._generate_item(
                 descendant_obj=profile_obj,
@@ -293,7 +276,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
                     autoinstall_data=autoinstall_data,
                 )
 
-        # fill temporary directory with binaries (kernel, initrd, installer, what else?)
+        # copy isolinux, kernels, initrds, and distro files (e.g. installer)
         self._copy_isolinux_files()
         for copyset in loader_config_parts.bootfiles_copysets:
             self._copy_boot_files(
@@ -308,6 +291,13 @@ class StandaloneBuildiso(buildiso.BuildIso):
             )
         self._copy_distro_files(filesource, str(buildiso_dirs.root))
 
+        # create EFI system partition (ESP) if needed, uses the ESP from the
+        # distro if it was copied
+        esp_location = self._find_esp(buildiso_dirs.root)
+        if esp_location is None:
+            esp_location = self._create_esp_image_file(buildisodir)
+            self._copy_grub_into_esp(esp_location, distro_obj.arch)
+
         # sync repos
         if airgapped:
             buildiso_dirs.repo.mkdir(exist_ok=True)
@@ -315,5 +305,6 @@ class StandaloneBuildiso(buildiso.BuildIso):
                 autoinstall_data.values(), repo_mirrordir, buildiso_dirs.repo
             )
         self._write_isolinux_cfg(loader_config_parts.isolinux, buildiso_dirs.isolinux)
+        self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)
         self._write_autoinstall_cfg(autoinstall_data, buildiso_dirs.autoinstall)
-        self._generate_iso(xorrisofs_opts, iso, buildisodir)
+        self._generate_iso(xorrisofs_opts, iso, buildisodir, esp_location)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -4,15 +4,17 @@ This module contains the specific code for generating standalone or airgapped IS
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+import itertools
 import os
+import pathlib
 import re
-from typing import Dict, List
+from typing import Dict, List, Iterable, Tuple
 
 from cobbler import utils
-
 from cobbler.actions import buildiso
+from cobbler.actions.buildiso import BootFilesCopyset, LoaderCfgsParts, Autoinstall
 
-cdregex = re.compile(r"^\s*url .*\n", re.IGNORECASE | re.MULTILINE)
+CDREGEX = re.compile(r"^\s*url .*\n", re.IGNORECASE | re.MULTILINE)
 
 
 def _generate_append_line_standalone(data: dict, distro, descendant) -> str:
@@ -48,258 +50,145 @@ class StandaloneBuildiso(buildiso.BuildIso):
     This class contains all functionality related to building self-contained installation images.
     """
 
-    def _validate_standalone_args(self, distro_name: str, source: str):
+    def _find_distro_source(self, known_file: str, distro_mirror: str) -> str:
         """
-        If building standalone, we only want --distro and --profiles (optional), systems are disallowed
-        :param distro_name: The name of the distribution we want to install.
-        :param source: The source which we copy to the ISO as an installation base.
-        """
-        if not distro_name:
-            raise ValueError(
-                "When building a standalone ISO, you must specify a --distro"
-            )
-        base_distro = self.api.find_distro(name=distro_name)
-        if base_distro is None:
-            raise ValueError("Distro specified was not found!")
-        source = self._validate_standalone_filesource(source, base_distro)
-        if not os.path.exists(source):
-            raise ValueError('The specified source "%s" does not exist!' % source)
+        Find a distro source tree based on a known file.
 
-        # Ensure all profiles specified are children of the distro
-        if self.profiles:
-            orphan_profiles = [
-                profile
-                for profile in self.profiles
-                if profile not in base_distro.children
-            ]
-            if len(orphan_profiles) > 0:
+        :param known_file: Path to a file that's known to be part of the distribution,
+            commonly the path to the kernel.
+        :raises ValueError: When no installation source was not found.
+        :return: Root of the distribution's source tree.
+        """
+        self.logger.debug("Trying to locate source.")
+        (source_head, source_tail) = os.path.split(known_file)
+        filesource = None
+        while source_tail != "":
+            if source_head == distro_mirror:
+                filesource = os.path.join(source_head, source_tail)
+                self.logger.debug("Found source in %s", filesource)
+                break
+            (source_head, source_tail) = os.path.split(source_head)
+
+        if filesource:
+            return filesource
+        else:
+            raise ValueError(
+                "No installation source found. When building a standalone (incl. airgapped) ISO"
+                " you must specify a --source if the distro install tree is not hosted locally"
+            )
+
+    def _write_autoinstall_cfg(
+        self, data: Dict[str, Autoinstall], output_dir: pathlib.Path
+    ):
+        self.logger.info("Writing auto-installation config files")
+        self.logger.debug(data)
+        for file_name, autoinstall in data.items():
+            with open(output_dir / f"{file_name}.cfg", "w") as f:
+                f.write(autoinstall.config)
+
+    def _generate_descendant_config(
+        self, descendant, menu_indent: int, distro, append_line: str
+    ) -> Tuple[str, BootFilesCopyset]:
+        kernel_path = f"/{os.path.basename(distro.kernel)}"
+        isolinux_cfg = self._render_isolinux_entry(
+            append_line,
+            menu_name=descendant.name,
+            kernel_path=kernel_path,
+            menu_indent=menu_indent,
+        )
+        return (
+            isolinux_cfg,
+            BootFilesCopyset(distro.kernel, distro.initrd, ""),
+        )
+
+    def validate_repos(
+        self, profile_name: str, repo_names: List[str], repo_mirrordir: pathlib.Path
+    ):
+        """Sanity checks for repos to sync.
+
+        This function checks that repos are known to cobbler and have a local mirror directory.
+        Raises ValueError if any repo fails the validation.
+        """
+        for repo_name in repo_names:
+            repo_obj = self.api.find_repo(name=repo_name)
+            if repo_obj is None:
                 raise ValueError(
-                    "When building a standalone ISO, all --profiles must be under --distro"
+                    f"Repository {repo_name}, referenced by {profile_name}, not found."
+                )
+            if not repo_obj.mirror_locally:
+                raise ValueError(
+                    f"Repository {repo_name} is not configured for local mirroring."
+                )
+            if not repo_mirrordir.joinpath(repo_name).exists():
+                raise ValueError(
+                    f"Local mirror directory missing for repository {repo_name}"
                 )
 
-    def _sync_airgapped_repos(self, airgapped: bool, repo_names_to_copy: dict):
-        """
-        Syncs all repositories locally available into the image if the is supposed to be airgapped.
-        :param airgapped: If false this method is doing nothing.
-        :param repo_names_to_copy: The names of the repositories which should be included.
-        :raises RuntimeError: In case the rsync of the repository was not successful.
-        """
+    def _generate_item(
+        self,
+        descendant_obj,
+        distro_obj,
+        airgapped,
+        cfg_parts,
+        repo_mirrordir,
+        autoinstall_data,
+    ):
+        self.logger.debug("Generating buildiso data for %s:%s", descendant_obj.TYPE_NAME, descendant_obj.name)
+        data: dict = utils.blender(self.api, False, descendant_obj)
+        utils.kopts_overwrite(
+            data["kernel_options"], self.api.settings().server, distro_obj.breed
+        )
+        append_line = _generate_append_line_standalone(data, distro_obj, descendant_obj)
+        name = descendant_obj.name
+        config_args = {
+            "descendant": descendant_obj,
+            "distro": distro_obj,
+            "append_line": append_line,
+        }
+        if descendant_obj.COLLECTION_TYPE == "profile":
+            config_args.update({"menu_indent": 0})
+            autoinstall_args = {"profile": descendant_obj}
+        else:  # system
+            config_args.update({"menu_indent": 4})
+            autoinstall_args = {"system": descendant_obj}
+        isolinux, to_copy = self._generate_descendant_config(**config_args)
+        autoinstall = self.api.autoinstallgen.generate_autoinstall(**autoinstall_args)
+
+        if distro_obj.breed == "redhat":
+            autoinstall = CDREGEX.sub("cdrom\n", autoinstall, count=1)
+
+        repos = []
         if airgapped:
-            # copy any repos found in profiles or systems to the iso build
-            repodir = os.path.abspath(
-                os.path.join(self.isolinuxdir, "..", "repo_mirror")
-            )
-            if not os.path.exists(repodir):
-                os.makedirs(repodir)
-
-            for repo_name in repo_names_to_copy:
-                self.logger.info(" - copying repo '%s' for airgapped ISO", repo_name)
-                rsync_successful = utils.rsync_files(
-                    repo_names_to_copy[repo_name],
-                    os.path.join(repodir, repo_name),
-                    "--exclude=TRANS.TBL --exclude=cache/ --no-g",
-                    quiet=True,
+            repos = data.get("repos", [])
+            if repos:
+                self.validate_repos(name, repos, repo_mirrordir)
+                autoinstall = re.sub(
+                    rf"^(\s*repo --name=\S+ --baseurl=).*/cobbler/distro_mirror/{distro_obj.name}/?(.*)",
+                    rf"\1 file:///mnt/source/repo_mirror/\2",
+                    autoinstall,
+                    re.MULTILINE,
                 )
-                if not rsync_successful:
-                    raise RuntimeError('rsync of repo "%s" failed' % repo_name)
+            autoinstall = self._update_repos_in_autoinstall_data(autoinstall, repos)
+        cfg_parts.isolinux.append(isolinux)
+        cfg_parts.bootfiles_copysets.append(to_copy)
+        autoinstall_data[name] = Autoinstall(autoinstall, repos)
 
-    def _validate_standalone_filesource(self, filesource: str, distro) -> str:
-        """
-        Validate that the path to the installation sources is making sense. If they do then normalize the path and
-        return it.
-        :param filesource: The path to the installation sources.
-        :param distro: The distribution of which the kernel is used for booting the image.
-        :raises ValueError: In case the installation source was not found.
-        :return: Normalized filesource which points to the absolute path of the source tree.
-        """
-        if not filesource:
-            # Try to determine the source from the distro kernel path
-            self.logger.debug("Trying to locate source for distro")
-            (source_head, source_tail) = os.path.split(distro.kernel)
-            distro_mirror = os.path.join(self.api.settings().webdir, "distro_mirror")
-            while source_tail != "":
-                if source_head == distro_mirror:
-                    filesource = os.path.join(source_head, source_tail)
-                    self.logger.debug("Found source in %s", filesource)
-                    return filesource
-                (source_head, source_tail) = os.path.split(source_head)
-            # Can't find the source, raise an error
-            raise ValueError(
-                "Error, no installation source found. When building a standalone or airgapped ISO, you must specify a "
-                "--source if the distro install tree is not hosted locally"
-            )
-        return filesource
-
-    def _generate_autoinstall_data(
-        self, descendant, distro, airgapped: bool, data: dict, repo_names_to_copy: dict
-    ) -> str:
-        """
-        Generates the autoinstall script for the distro/profile/system we want to install.
-        :param descendant: The descendant to generate the ISO for.
-        :param distro: The distro to generate the ISO for.
-        :param airgapped: Whether the ISO should be bootable in an airgapped environment or not.
-        :param data: The data for the append line of the kernel.
-        :param repo_names_to_copy: The repositories to include in case of an airgapped environment.
-        :return: The generated script for the ISO.
-        """
-        autoinstall_data = ""
-        if descendant.COLLECTION_TYPE == "profile":
-            autoinstall_data = self.api.autoinstallgen.generate_autoinstall_for_profile(
-                descendant.name
-            )
-        elif descendant.COLLECTION_TYPE == "system":
-            autoinstall_data = self.api.autoinstallgen.generate_autoinstall_for_system(
-                descendant.name
-            )
-
-        if distro.breed == "redhat":
-            autoinstall_data = cdregex.sub("cdrom\n", autoinstall_data, count=1)
-
-        if airgapped:
-            for repo_name in data.get("repos", []):
-                repo_obj = self.api.find_repo(repo_name)
-                error = (
-                    "%s %s refers to repo %s, which {error_message}; cannot build airgapped ISO"
-                    % (descendant.COLLECTION_TYPE, descendant.name, repo_name)
-                )
-
-                if repo_obj is None:
-                    raise ValueError(error.format(error_message="does not exist"))
-                if not repo_obj.mirror_locally:
-                    raise ValueError(
-                        error.format(
-                            error_message="is not configured for local mirroring"
-                        )
-                    )
-                mirrordir = os.path.join(
-                    self.api.settings().webdir, "repo_mirror", repo_obj.name
-                )
-                if not os.path.exists(mirrordir):
-                    raise ValueError(
-                        error.format(
-                            error_message="has a missing local mirror directory"
-                        )
-                    )
-
-                repo_names_to_copy[repo_obj.name] = mirrordir
-
-                # update the baseurl in autoinstall_data to use the cdrom copy of this repo
-                reporegex = re.compile(
-                    r"^(\s*repo --name=%s --baseurl=).*" % repo_obj.name, re.MULTILINE
-                )
-                autoinstall_data = reporegex.sub(
-                    r"\1" + "file:///mnt/source/repo_mirror/" + repo_obj.name,
-                    autoinstall_data,
-                )
-
-            # rewrite any split-tree repos, such as in redhat, to use cdrom
-            srcreporegex = re.compile(
-                r"^(\s*repo --name=\S+ --baseurl=).*/cobbler/distro_mirror/%s/?(.*)"
-                % distro.name,
+    def _update_repos_in_autoinstall_data(self, autoinstall_data, repos_names) -> str:
+        for repo_name in repos_names:
+            autoinstall_data = re.sub(
+                rf"^(\s*repo --name={repo_name} --baseurl=).*",
+                rf"\1 file:///mnt/source/repo_mirror/{repo_name}",
+                autoinstall_data,
                 re.MULTILINE,
-            )
-            autoinstall_data = srcreporegex.sub(
-                r"\1" + "file:///mnt/source" + r"\2", autoinstall_data
             )
         return autoinstall_data
 
-    def _generate_descendant(
-        self,
-        descendant,
-        cfglines: List[str],
-        distro,
-        airgapped: bool,
-        repo_names_to_copy: dict,
-    ):
+    def _copy_distro_files(self, filesource: str, output_dir: str):
+        """Copy the distro tree in filesource to output_dir.
+
+        :param filesource: Path to root of the distro source tree.
+        :param output_dir: Path to the directory into which to copy all files.
         """
-        Generate the ISOLINUX cfg configuration file for the descendant.
-        :param descendant: The descendant to generate the config file for. Must be a profile or system object.
-        :param cfglines: The content of the file which has already been generated.
-        :param distro: The parent distro.
-        :param airgapped: Whether the generated ISO should be bootable in an airgapped environment or not.
-        :param repo_names_to_copy: The repository names to copy in the case of an airgapped environment.
-        """
-        menu_indent = 0
-        if descendant.COLLECTION_TYPE == "system":
-            menu_indent = 4
-
-        data = utils.blender(self.api, False, descendant)
-
-        # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-        if distro is not None:
-            utils.kopts_overwrite(
-                data["kernel_options"], self.api.settings().server, distro.breed
-            )
-
-        cfglines.append("")
-        cfglines.append("LABEL %s" % descendant.name)
-        if menu_indent:
-            cfglines.append("  MENU INDENT %d" % menu_indent)
-        cfglines.append("  MENU LABEL %s" % descendant.name)
-        cfglines.append("  KERNEL %s" % os.path.basename(distro.kernel))
-
-        cfglines.append(_generate_append_line_standalone(data, distro, descendant))
-
-        autoinstall_data = self._generate_autoinstall_data(
-            descendant, distro, airgapped, data, repo_names_to_copy
-        )
-        autoinstall_name = os.path.join(self.isolinuxdir, "%s.cfg" % descendant.name)
-        with open(autoinstall_name, "w+") as autoinstall_file:
-            autoinstall_file.write(autoinstall_data)
-
-    def generate_standalone_iso(
-        self, distro_name: str, filesource: str, airgapped: bool
-    ):
-        """Creates the ``isolinux.cfg`` for a standalone or airgapped ISO image. And copies possible repositories to
-        the image source folder.
-        :param distro_name: The name of the Cobbler distribution.
-        :param filesource: The source directory for the ISO. This gets rsynced into isolinuxdir.
-        :param airgapped: Whether the repositories have to be locally available or the internet is reachable.
-        """
-        # Get the distro object for the requested distro and then get all of its descendants (profiles/sub-profiles/
-        # systems) with sort=True for profile/system hierarchy to allow menu indenting
-        distro = self.api.find_distro(name=distro_name)
-        if distro is None:
-            raise ValueError(
-                'Distro "%s" was not found, aborting generation of ISO-file!'
-                % distro_name
-            )
-
-        self.copy_boot_files(distro, self.isolinuxdir)
-
-        self.logger.info("generating an isolinux.cfg")
-
-        cfglines = [self.iso_template]
-
-        repo_names_to_copy: Dict[str, str] = {}
-
-        for descendant in distro.children:
-            descendant = self.api.find_items(what="", name=descendant)
-            # if a list of profiles was given, skip any others and their systems
-            if len(self.profiles) > 0 and (
-                (
-                    descendant.COLLECTION_TYPE == "profile"
-                    and descendant.name not in self.profiles
-                )
-                or (
-                    descendant.COLLECTION_TYPE == "system"
-                    and descendant.profile not in self.profiles
-                )
-            ):
-                continue
-            self._generate_descendant(
-                descendant, cfglines, distro, airgapped, repo_names_to_copy
-            )
-
-        cfglines.append("")
-        cfglines.append("MENU END")
-        with open(os.path.join(self.isolinuxdir, "isolinux.cfg"), "w+") as cfg:
-            cfg.writelines("%s\n" % l for l in cfglines)
-        self.logger.info("done writing config")
-
-        self._sync_airgapped_repos(airgapped, repo_names_to_copy)
-
-        # copy distro files last, since they take the most time
         cmd = [
             "rsync",
             "-rlptgu",
@@ -309,13 +198,43 @@ class StandaloneBuildiso(buildiso.BuildIso):
             "TRANS.TBL",
             "--exclude",
             "isolinux/",
-            "%s/" % filesource,
-            "%s/../" % self.isolinuxdir,
+            f"{filesource}/",
+            f"{output_dir}/",
         ]
-        self.logger.info('- copying distro "%s" files (%s)', distro_name, cmd)
-        rsync_return_code = utils.subprocess_call(cmd, shell=False)
-        if rsync_return_code:
-            raise OSError("rsync of distro files failed")
+        self.logger.info('- copying distro files (%s)', cmd)
+        rc = utils.subprocess_call(cmd, shell=False)
+        if rc != 0:
+            raise RuntimeError("rsync of distro files failed")
+
+    def _copy_repos(
+        self,
+        autoinstall_data: Iterable[Autoinstall],
+        source_dir: pathlib.Path,
+        output_dir: pathlib.Path,
+    ):
+        """Copy repos for airgapped ISOs.
+
+        The caller of this function has to check if an airgapped ISO is built.
+        :param autoinstall_data: Iterable of Autoinstall records that contain the lists of repos.
+        :param source_dir: Path to the directory containing the repos.
+        :param output_dir: Path to the directory into which to copy all files.
+        :raises RuntimeError: rsync command failed.
+        """
+        for repo in itertools.chain.from_iterable(ai.repos for ai in autoinstall_data):
+            self.logger.info(" - copying repo '%s' for airgapped iso", repo)
+            cmd = [
+                "rsync",
+                "-rlptgu",
+                "--exclude",
+                "boot.cat",
+                "--exclude",
+                "TRANS.TBL",
+                f"{source_dir / repo}/",
+                str(output_dir),
+            ]
+            rc = utils.subprocess_call(cmd, shell=False)
+            if rc != 0:
+                raise RuntimeError(f"Copying of repo {repo} failed.")
 
     def run(
         self,
@@ -343,7 +262,58 @@ class StandaloneBuildiso(buildiso.BuildIso):
         """
         del kwargs  # just accepted for polymorphism
 
-        buildisodir = self._prepare_iso(buildisodir, distro_name, profiles)
-        self._validate_standalone_args(distro_name, source)
-        self.generate_standalone_iso(distro_name, source, airgapped)
+        self.logger.info("Generating standalone ISO for distro %s", distro_name)
+        distro_obj = self.parse_distro(distro_name)
+        profile_objs = self.parse_profiles(profiles, distro_obj)
+        filesource = source
+        loader_config_parts = LoaderCfgsParts([self.iso_template], [])
+        autoinstall_data: Dict[str, Autoinstall] = {}
+        buildisodir = self._prepare_buildisodir(buildisodir)
+        buildiso_dirs = self.create_buildiso_dirs(buildisodir)
+        repo_mirrordir = pathlib.Path(self.api.settings().webdir) / "repo_mirror"
+        distro_mirrordir = pathlib.Path(self.api.settings().webdir) / "distro_mirror"
+
+        for profile_obj in profile_objs:
+            self._generate_item(
+                descendant_obj=profile_obj,
+                distro_obj=distro_obj,
+                airgapped=airgapped,
+                cfg_parts=loader_config_parts,
+                repo_mirrordir=repo_mirrordir,
+                autoinstall_data=autoinstall_data,
+            )
+            for descendant in profile_obj.descendants:
+                # handle everything below this top-level profile
+                self._generate_item(
+                    descendant_obj=descendant,
+                    distro_obj=distro_obj,
+                    airgapped=airgapped,
+                    cfg_parts=loader_config_parts,
+                    repo_mirrordir=repo_mirrordir,
+                    autoinstall_data=autoinstall_data,
+                )
+
+        # fill temporary directory with binaries (kernel, initrd, installer, what else?)
+        self._copy_isolinux_files()
+        for copyset in loader_config_parts.bootfiles_copysets:
+            self._copy_boot_files(
+                copyset.src_kernel,
+                copyset.src_initrd,
+                str(buildiso_dirs.root),
+                copyset.new_filename,
+            )
+        if not filesource:
+            filesource = self._find_distro_source(
+                distro_obj.kernel, str(distro_mirrordir)
+            )
+        self._copy_distro_files(filesource, str(buildiso_dirs.root))
+
+        # sync repos
+        if airgapped:
+            buildiso_dirs.repo.mkdir(exist_ok=True)
+            self._copy_repos(
+                autoinstall_data.values(), repo_mirrordir, buildiso_dirs.repo
+            )
+        self._write_isolinux_cfg(loader_config_parts.isolinux, buildiso_dirs.isolinux)
+        self._write_autoinstall_cfg(autoinstall_data, buildiso_dirs.autoinstall)
         self._generate_iso(xorrisofs_opts, iso, buildisodir)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -326,6 +326,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         distro_name: str = "",
         airgapped: bool = False,
         source="",
+        **kwargs,
     ):
         """
         Run the whole iso generation from bottom to top. Per default this builds an ISO for all available systems
@@ -340,6 +341,8 @@ class StandaloneBuildiso(buildiso.BuildIso):
         :param airgapped: This option implies ``standalone=True``.
         :param source: If the iso should be offline available this is the path to the sources of the image.
         """
+        del kwargs  # just accepted for polymorphism
+
         buildisodir = self._prepare_iso(buildisodir, distro_name, profiles)
         self._validate_standalone_args(distro_name, source)
         self.generate_standalone_iso(distro_name, source, airgapped)

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1899,14 +1899,18 @@ class CobblerAPI:
             raise TypeError("Argument \"airgapped\" needs to be of type bool!")
         if airgapped:
             standalone = True
-        if standalone:
-            standalone_builder = StandaloneBuildiso(self)
-            standalone_builder.run(iso=iso, buildisodir=buildisodir, profiles=profiles, xorrisofs_opts=xorrisofs_opts,
-                                   distro_name=distro_name, airgapped=airgapped, source=source)
-        else:
-            netboot_builder = NetbootBuildiso(self)
-            netboot_builder.run(iso=iso, buildisodir=buildisodir, profiles=profiles, xorrisofs_opts=xorrisofs_opts,
-                                distro_name=distro_name, systems=systems, exclude_dns=exclude_dns)
+        Builder = StandaloneBuildiso if standalone else NetbootBuildiso
+        Builder(self).run(
+            iso=iso,
+            buildisodir=buildisodir,
+            profiles=profiles,
+            xorrisofs_opts=xorrisofs_opts,
+            distro_name=distro_name,
+            airgapped=airgapped,
+            source=source,
+            systems=systems,
+            exclude_dns=exclude_dns,
+        )
 
     # ==========================================================================
 

--- a/cobbler/autoinstallgen.py
+++ b/cobbler/autoinstallgen.py
@@ -294,9 +294,9 @@ class AutoInstallationGen:
             return "# automatic installation file value missing or invalid at %s %s" % (obj_type, obj.name)
 
         # get parent distro
-        distro = profile.get_conceptual_parent()
         if system is not None:
-            distro = system.get_conceptual_parent().get_conceptual_parent()
+            profile = system.get_conceptual_parent()
+        distro = profile.get_conceptual_parent()
 
         # make autoinstall_meta metavariable available at top level
         autoinstall_meta = meta["autoinstall_meta"]

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -37,6 +37,7 @@ class Distro(item.Item):
     # Constants
     TYPE_NAME = "distro"
     COLLECTION_TYPE = "distro"
+    CHILD_TYPES = ["profile"]
 
     def __init__(self, api, *args, **kwargs):
         """

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -33,6 +33,7 @@ class Image(item.Item):
 
     TYPE_NAME = "image"
     COLLECTION_TYPE = "image"
+    CHILD_TYPES = ["system"]
 
     def __init__(self, api, *args, **kwargs):
         """

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -35,6 +35,7 @@ class Item:
     # Constants
     TYPE_NAME = "generic"
     COLLECTION_TYPE = "generic"
+    CHILD_TYPES = []
 
     @classmethod
     def __find_compare(cls, from_search: Union[str, list, dict, bool], from_obj: Union[str, list, dict, bool]):
@@ -731,13 +732,17 @@ class Item:
 
         :getter: This is a list of all descendants. May be empty if none exist.
         """
-        results = []
-        kids = self.children
-        for kid in kids:
-            # FIXME: Get kid objects
-            grandkids = kid.descendants
-            results.extend(grandkids)
-        return results
+        descendants = []
+        for child in self.children:
+            # different types with same name are possible
+            for child_type in self.CHILD_TYPES:
+                child_object = self.api.find_items(what=child_type, name=child, return_list=False)
+                # child_object is self -> infinite recursion
+                if child_object and child_object is not self:
+                    descendants.append(child_object)
+                    descendants.extend(child_object.descendants)
+
+        return descendants
 
     @property
     def is_subobject(self) -> bool:

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -30,6 +30,7 @@ class Menu(item.Item):
     """
 
     COLLECTION_TYPE = "menu"
+    CHILD_TYPES = ["menu"]
 
     def __init__(self, api, *args, **kwargs):
         """

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -35,6 +35,7 @@ class Profile(item.Item):
 
     TYPE_NAME = "profile"
     COLLECTION_TYPE = "profile"
+    CHILD_TYPES = ["profile", "system", "image"]
 
     def __init__(self, api, *args, **kwargs):
         """

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -735,6 +735,7 @@ class System(Item):
     # Constants
     TYPE_NAME = "system"
     COLLECTION_TYPE = "system"
+    CHILD_TYPES = ["system"]
 
     def __init__(self, api, *args, **kwargs):
         """
@@ -2026,7 +2027,7 @@ class System(Item):
         :setter: Sets the value for the property ``children``.
         :return:
         """
-        return self._children
+        return [c.name for c in self._children]
 
     @children.setter
     def children(self, value: List[str]):

--- a/docker/debs/Debian_10/Debian10.dockerfile
+++ b/docker/debs/Debian_10/Debian10.dockerfile
@@ -60,7 +60,8 @@ RUN apt-get update -qq && \
     libapache2-mod-wsgi-py3 \
     iproute2 \
     systemd \
-    supervisor && \
+    supervisor \
+    dosfstools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Make /bin/sh point to bash, not dash

--- a/docker/debs/Debian_11/Debian11.dockerfile
+++ b/docker/debs/Debian_11/Debian11.dockerfile
@@ -62,7 +62,8 @@ RUN apt-get update -qq && \
     iproute2 \
     systemd \
     systemd-sysv \
-    supervisor && \
+    supervisor \
+    dosfstools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Make /bin/sh point to bash, not dash

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -48,7 +48,8 @@ RUN zypper install --no-recommends -y \
     vim                        \
     wget                       \
     which                      \
-    xorriso
+    xorriso                    \
+    dosfstools
 
 # Add virtualization repository
 RUN zypper ar https://download.opensuse.org/repositories/Virtualization/15.3/Virtualization.repo

--- a/docker/rpms/Fedora_34/Fedora34.dockerfile
+++ b/docker/rpms/Fedora_34/Fedora34.dockerfile
@@ -49,7 +49,8 @@ RUN yum install -y          \
     fence-agents            \
     openldap-servers        \
     openldap-clients        \
-    supervisor
+    supervisor              \
+    dosfstools
 
 # Dependencies for system tests
 RUN dnf install -y          \

--- a/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
+++ b/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
@@ -60,7 +60,8 @@ RUN touch /var/lib/rpm/* &&   \
     syslinux                  \
     tftp-server               \
     fence-agents              \
-    supervisor
+    supervisor                \
+    dosfstools
 
 # Dependencies for system tests
 RUN touch /var/lib/rpm/* &&   \

--- a/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
@@ -45,7 +45,8 @@ RUN zypper install -y          \
     python3-PyYAML             \
     python3-wheel              \
     rpm-build                  \
-    which
+    which                      \
+    dosfstools
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -46,7 +46,8 @@ RUN zypper install -y          \
     python3-PyYAML             \
     python3-wheel              \
     rpm-build                  \
-    which
+    which                      \
+    dosfstools
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \

--- a/templates/iso/grub_menuentry.template
+++ b/templates/iso/grub_menuentry.template
@@ -1,0 +1,7 @@
+menuentry '$menu_name' --class gnu-linux --class gnu --class os {
+  echo 'Loading kernel ...'
+  linux $kernel_path $kernel_options
+  echo 'Loading initial ramdisk ...'
+  initrd $initrd_path
+  echo '...done'
+}

--- a/templates/iso/isolinux_menuentry.template
+++ b/templates/iso/isolinux_menuentry.template
@@ -1,0 +1,8 @@
+LABEL {{ menu_name }}
+{%- if menu_indent %}
+  MENU INDENT {{ menu_indent }}
+{% endif %}
+  MENU LABEL {{ menu_name }}
+  KERNEL {{ kernel_path }}
+  {{ append_line }}
+

--- a/tests/actions/buildiso/append_line_test.py
+++ b/tests/actions/buildiso/append_line_test.py
@@ -26,7 +26,7 @@ def test_generate_system(
     # TODO: Make tests more sophisticated
     assert (
         result
-        == "  APPEND initrd=%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
+        == "  APPEND initrd=/%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
         % (request.node.name, request.node.name)
     )
 
@@ -46,6 +46,6 @@ def test_generate_profile(request, cobbler_api, create_distro, create_profile):
     # TODO: Make tests more sophisticated
     assert (
         result
-        == "  APPEND initrd=%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
+        == "  APPEND initrd=/%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
         % (request.node.name, request.node.name)
     )

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -29,17 +29,13 @@ def test_calculate_grub_name(
     result_binary_name,
     expected_exception,
     cobbler_api,
-    create_distro,
 ):
     # Arrange
     test_builder = buildiso.BuildIso(cobbler_api)
-    test_distro = create_distro()
-    test_distro.arch = input_arch
-    cobbler_api.add_distro(test_distro)
 
     # Act
     with expected_exception:
-        result = test_builder.calculate_grub_name(test_distro)
+        result = test_builder.calculate_grub_name(input_arch)
 
         # Assert
         assert result in result_binary_name
@@ -111,11 +107,16 @@ def test_netboot_generate_boot_loader_configs(
     matching_isolinux_initrd = [
         part for part in result.isolinux if "initrd=/1.img" in part
     ]
+    matching_grub_kernel = [part for part in result.grub if "linux /1.krn" in part]
+    matching_grub_initrd = [part for part in result.grub if "initrd /1.img" in part]
+
     # Assert
     assert isinstance(result, LoaderCfgsParts)
     for iterable_to_check in [
         matching_isolinux_kernel,
         matching_isolinux_initrd,
+        matching_grub_kernel,
+        matching_grub_initrd,
         result.bootfiles_copysets,
     ]:
         print(iterable_to_check)

--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -384,3 +384,12 @@ def test_supported_boot_loaders(cobbler_api):
     # Assert
     assert isinstance(distro.supported_boot_loaders, list)
     assert distro.supported_boot_loaders == ["grub", "pxe", "ipxe"]
+
+def test_descendants(create_distro, create_profile, create_system):
+    d = create_distro()
+    p = create_profile(d.name)
+    s = create_system(p.name)
+
+    result = d.descendants
+
+    assert result == [p, s]


### PR DESCRIPTION
## Linked Items

Fixes https://github.com/SUSE/spacewalk/issues/19769

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Backport of https://github.com/cobbler/cobbler/pull/3357. 

## Behaviour changes

Old: `cobbler buildiso` creates images that can only be booted with BIOS+Isolinux
New: `cobbler buildiso` creates images that can be booted with BIOS+Isolinux or EFI+Grub2

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
