### PR TITLE
Expose input converters to the API

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2026,3 +2026,53 @@ class CobblerAPI:
         """
         action = mkloaders.MkLoaders(self)
         action.run()
+
+    # ==========================================================================
+
+    def input_string_or_list_no_inherit(
+        self, options: Optional[Union[str, list]]
+    ) -> list:
+        """
+        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_list_no_inherit`
+        """
+        return input_converters.input_string_or_list_no_inherit(options)
+
+    def input_string_or_list(
+        self, options: Optional[Union[str, list]]
+    ) -> Union[list, str]:
+        """
+        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_list`
+        """
+        return input_converters.input_string_or_list(options)
+
+    def input_string_or_dict(
+        self, options: Union[str, list, dict], allow_multiples=True
+    ) -> Union[str, dict]:
+        """
+        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_dict`
+        """
+        return input_converters.input_string_or_dict(
+            options, allow_multiples=allow_multiples
+        )
+
+    def input_string_or_dict_no_inherit(
+        self, options: Union[str, list, dict], allow_multiples=True
+    ) -> dict:
+        """
+        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_dict_no_inherit`
+        """
+        return input_converters.input_string_or_dict_no_inherit(
+            options, allow_multiples=allow_multiples
+        )
+
+    def input_boolean(self, value: Union[str, bool, int]) -> bool:
+        """
+        .. seealso:: :func:`~cobbler.utils.input_converters.input_boolean`
+        """
+        return input_converters.input_boolean(value)
+
+    def input_int(self, value: Union[str, int, float]) -> int:
+        """
+        .. seealso:: :func:`~cobbler.utils.input_converters.input_int`
+        """
+        return input_converters.input_int(value)

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2033,25 +2033,25 @@ class CobblerAPI:
         self, options: Optional[Union[str, list]]
     ) -> list:
         """
-        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_list_no_inherit`
+        .. seealso:: :func:`~cobbler.utils.input_string_or_list_no_inherit`
         """
-        return input_converters.input_string_or_list_no_inherit(options)
+        return utils.input_string_or_list_no_inherit(options)
 
     def input_string_or_list(
         self, options: Optional[Union[str, list]]
     ) -> Union[list, str]:
         """
-        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_list`
+        .. seealso:: :func:`~cobbler.utils.input_string_or_list`
         """
-        return input_converters.input_string_or_list(options)
+        return utils.input_string_or_list(options)
 
     def input_string_or_dict(
         self, options: Union[str, list, dict], allow_multiples=True
     ) -> Union[str, dict]:
         """
-        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_dict`
+        .. seealso:: :func:`~cobbler.utils.input_string_or_dict`
         """
-        return input_converters.input_string_or_dict(
+        return utils.input_string_or_dict(
             options, allow_multiples=allow_multiples
         )
 
@@ -2059,20 +2059,20 @@ class CobblerAPI:
         self, options: Union[str, list, dict], allow_multiples=True
     ) -> dict:
         """
-        .. seealso:: :func:`~cobbler.utils.input_converters.input_string_or_dict_no_inherit`
+        .. seealso:: :func:`~cobbler.utils.input_string_or_dict_no_inherit`
         """
-        return input_converters.input_string_or_dict_no_inherit(
+        return utils.input_string_or_dict_no_inherit(
             options, allow_multiples=allow_multiples
         )
 
     def input_boolean(self, value: Union[str, bool, int]) -> bool:
         """
-        .. seealso:: :func:`~cobbler.utils.input_converters.input_boolean`
+        .. seealso:: :func:`~cobbler.utils.input_boolean`
         """
-        return input_converters.input_boolean(value)
+        return utils.input_boolean(value)
 
     def input_int(self, value: Union[str, int, float]) -> int:
         """
-        .. seealso:: :func:`~cobbler.utils.input_converters.input_int`
+        .. seealso:: :func:`~cobbler.utils.input_int`
         """
-        return input_converters.input_int(value)
+        return utils.input_int(value)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1981,13 +1981,13 @@ class CobblerXMLRPCInterface:
             elif isinstance(getattr(self.api.settings(), setting_name), int):
                 value = int(value)
             elif isinstance(getattr(self.api.settings(), setting_name), bool):
-                value = utils.input_boolean(value)
+                value = self.api.input_boolean(value)
             elif isinstance(getattr(self.api.settings(), setting_name), float):
                 value = float(value)
             elif isinstance(getattr(self.api.settings(), setting_name), list):
-                value = utils.input_string_or_list(value)
+                value = self.api.input_string_or_list(value)
             elif isinstance(getattr(self.api.settings(), setting_name), dict):
-                value = utils.input_string_or_dict(value)
+                value = self.api.input_string_or_dict(value)
             else:
                 self.logger.error("modify_setting(%s) - Wrong type for value", setting_name)
                 return 1
@@ -2110,7 +2110,7 @@ class CobblerXMLRPCInterface:
                             and attributes.get("in_place"):
                         details = self.get_item(object_type, object_name)
                         v2 = details[key]
-                        parsed_input = utils.input_string_or_dict(value)
+                        parsed_input = self.api.input_string_or_dict(value)
                         for (a, b) in list(parsed_input.items()):
                             if a.startswith("~") and len(a) > 1:
                                 del v2[a[1:]]
@@ -3695,6 +3695,52 @@ class CobblerXMLRPCInterface:
         self.check_access(token, "clear_system_logs", obj)
         self.api.clear_logs(obj)
         return True
+
+    def input_string_or_list_no_inherit(
+        self, options: Optional[Union[str, list]]
+    ) -> list:
+        """
+        .. seealso:: :func:`~cobbler.api.CobblerAPI.input_string_or_list_no_inherit`
+        """
+        return self.api.input_string_or_list_no_inherit(options)
+
+    def input_string_or_list(
+        self, options: Optional[Union[str, list]]
+    ) -> Union[list, str]:
+        """
+        .. seealso:: :func:`~cobbler.api.CobblerAPI.input_string_or_list`
+        """
+        return self.api.input_string_or_list(options)
+
+    def input_string_or_dict(
+        self, options: Union[str, list, dict], allow_multiples=True
+    ) -> Union[str, dict]:
+        """
+        .. seealso:: :func:`~cobbler.api.CobblerAPI.input_string_or_dict`
+        """
+        return self.api.input_string_or_dict(options, allow_multiples=allow_multiples)
+
+    def input_string_or_dict_no_inherit(
+        self, options: Union[str, list, dict], allow_multiples=True
+    ) -> dict:
+        """
+        .. seealso:: :func:`~cobbler.api.CobblerAPI.input_string_or_dict_no_inherit`
+        """
+        return self.api.input_string_or_dict_no_inherit(
+            options, allow_multiples=allow_multiples
+        )
+
+    def input_boolean(self, value: Union[str, bool, int]) -> bool:
+        """
+        .. seealso:: :func:`~cobbler.api.CobblerAPI.input_boolean`
+        """
+        return self.api.input_boolean(value)
+
+    def input_int(self, value: Union[str, int, float]) -> int:
+        """
+        .. seealso:: :func:`~cobbler.api.CobblerAPI.input_int`
+        """
+        return self.api.input_int(value)
 
 
 # *********************************************************************************


### PR DESCRIPTION
## Linked Items

Fixes https://github.com/SUSE/spacewalk/issues/18243

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Backport of https://github.com/cobbler/cobbler/pull/3200

Since this backport of PR [#3200](https://github.com/cobbler/cobbler/pull/3200) follows PR [#3141](https://github.com/cobbler/cobbler/pull/3141), some imports were done to the utils submodules when it was split. We need to import directly the utils module when needed.

## Behaviour changes

Old: 

New: The functionality of all input_string_or* functions is now available via both XML-RPC or HTTP API.

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
