### PR TITLE
Backport Item: to_dict cache

### DIFF
--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -1,0 +1,27 @@
+name: Performance testing
+
+on:
+  push:
+    branches: [ suma/4.3, suma/head, uyuni/master ]
+  pull_request:
+    branches: [ suma/4.3, suma/head, uyuni/master ]
+
+jobs:
+  run_performance_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull Docker Test Container
+        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Run previously built Docker Container
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Setup Cobbler in the Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "./docker/develop/scripts/setup-supervisor.sh"
+      - name: Run the Performance Tests inside the Docker Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-only --benchmark-autosave tests/performance"
+      - name: Stop and remove the container
+        run: docker stop cobbler && docker rm cobbler

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,6 +23,6 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           # Excluding "tests/actions/mkloaders_test.py::test_grubimage_run" as it is only prepared for SUMA/Uyuni containers
-          docker exec -u 0 -it cobbler bash -c "pytest  -k 'not test_grubimage_run' --cov=./cobbler && codecov --token=1064928c-6477-41be-9ac2-7ce5e6d1fd8b --commit=${GITHUB_SHA}"
+          docker exec -u 0 -it cobbler bash -c "pytest  -k 'not test_grubimage_run' --benchmark-skip --cov=./cobbler && codecov --token=1064928c-6477-41be-9ac2-7ce5e6d1fd8b --commit=${GITHUB_SHA}"
       - name: Stop and remove the container
         run: docker stop cobbler && docker rm cobbler

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -39,6 +39,7 @@ from cobbler import settings, tftpgen, utils, yumgen
 from cobbler.cobbler_collections import manager
 from cobbler.items import distro, file, image, menu, mgmtclass, package, profile, repo, system
 from cobbler.decorator import InheritableDictProperty
+from cobbler.cexceptions import CX
 
 # FIXME: add --quiet depending on if not --verbose?
 RSYNC_CMD = "rsync -a %s '%s' %s --progress"
@@ -277,6 +278,34 @@ class CobblerAPI:
         else:
             return data
 
+    # ==========================================================================
+
+    def clean_items_cache(self, obj: Union[settings.Settings, Dict]):
+        """
+        Items cache invalidation in case of settings or singatures changes.
+        Cobbler internal use only.
+        """
+        if obj is None or isinstance(obj, settings.Settings):
+            item_types = [
+                "package",
+                "file",
+                "mgmtclass",
+                "repo",
+                "distro",
+                "menu",
+                "image",
+                "profile",
+                "system",
+            ]
+        elif obj == self.get_signatures():
+            item_types = ["distro", "image", "profile", "system"]
+        else:
+            raise CX(f"Wrong object type {type(obj)} for cache invalidation!")
+
+        for item_type in item_types:
+            for item_obj in self.get_items(item_type):
+                item_obj.cache.set_dict_cache(None, True)
+
     # ==========================================================
 
     def get_item(self, what: str, name: str):
@@ -442,7 +471,7 @@ class CobblerAPI:
             return
         # Deduplicate - only for dict
         if isinstance(property_object_of_attribute, InheritableDictProperty):
-            parent_item = desired_item.parent
+            parent_item = desired_item.logical_parent
             if hasattr(parent_item, attribute):
                 parent_value = getattr(parent_item, attribute)
                 dict_value = utils.input_string_or_dict(value)
@@ -1309,7 +1338,8 @@ class CobblerAPI:
             f.close()
 
             utils.load_signatures(self.settings().signature_path)
-        except:
+            self.clean_items_cache(self.get_signatures())
+        except Exception:
             utils.log_exc()
 
     # ==========================================================================

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -97,7 +97,7 @@ class Collection:
         """
         raise NotImplementedError("Please implement this in a child class of this class.")
 
-    def get(self, name: str):
+    def get(self, name: str) -> Optional[item_base.Item]:
         """
         Return object with name in the collection
 
@@ -277,23 +277,26 @@ class Collection:
             self.collection_mgr.serialize_one_item(ref)
             self.listing[newname] = ref
 
-        # for mgmt classes, update all objects that use it
-        if ref.COLLECTION_TYPE == "mgmtclass":
-            for what in ["distro", "profile", "system"]:
-                items = self.api.find_items(what, {"mgmt_classes": oldname})
-                for item in items:
-                    for i in range(0, len(item.mgmt_classes)):
-                        if item.mgmt_classes[i] == oldname:
-                            item.mgmt_classes[i] = newname
-                    self.api.add_item(what, item, save=True)
-
-        # for menus, update all objects that use it
-        if ref.COLLECTION_TYPE == "menu":
-            for what in ["profile", "image"]:
-                items = self.api.find_items(what, {"menu": oldname})
-                for item in items:
-                    item.menu = newname
-                    self.api.add_item(what, item, save=True)
+        for dep_type in item_base.Item.TYPE_DEPENDENCIES[ref.COLLECTION_TYPE]:
+            items = self.api.find_items(dep_type[0], {dep_type[1]: oldname}, return_list = True)
+            for item in items:
+                attr = getattr(item, "_" + dep_type[1])
+                if isinstance(attr, (str, item_base.Item)):
+                    setattr(item, dep_type[1], newname)
+                elif isinstance(attr, list):
+                    for i, attr_val in enumerate(attr):
+                        if attr_val == oldname:
+                            attr[i] = newname
+                else:
+                    raise CX(
+                        f'Internal error, unknown attribute type {type(attr)} for "{item.name}"!'
+                    )
+                self.api.get_items(item.COLLECTION_TYPE).add(
+                    item,
+                    save=True,
+                    with_sync=with_sync,
+                    with_triggers=with_triggers,
+                )
 
         # for a repo, rename the mirror directory
         if ref.COLLECTION_TYPE == "repo":
@@ -325,33 +328,6 @@ class Collection:
                         d.initrd = d.initrd.replace(path, newpath)
                         self.collection_mgr.serialize_one_item(d)
 
-        if ref.COLLECTION_TYPE in ('profile', 'system'):
-            if ref.parent is not None:
-                ref.parent.children.remove(oldname)
-
-        # Now descend to any direct ancestors and point them at the new object allowing the original object to be
-        # removed without orphanage. Direct ancestors will either be profiles or systems. Note that we do have to
-        # care as setting the parent is only really meaningful for subprofiles. We ideally want a more generic parent
-        # setter.
-        kids = ref.get_children()
-        for k in kids:
-            if self.api.find_profile(name=k) is not None:
-                k = self.api.find_profile(name=k)
-                if ref.COLLECTION_TYPE == "distro":
-                    k.distro = newname
-                else:
-                    k.parent = newname
-                self.api.profiles().add(k, save=True, with_sync=with_sync, with_triggers=with_triggers)
-            elif self.api.find_menu(name=k) is not None:
-                k = self.api.find_menu(name=k)
-                k.parent = newname
-                self.api.menus().add(k, save=True, with_sync=with_sync, with_triggers=with_triggers)
-            elif self.api.find_system(name=k) is not None:
-                k = self.api.find_system(name=k)
-                k.profile = newname
-                self.api.systems().add(k, save=True, with_sync=with_sync, with_triggers=with_triggers)
-            else:
-                raise CX("Internal error, unknown child type for child \"%s\"!" % k)
 
     def add(
         self,
@@ -422,11 +398,6 @@ class Collection:
         with self.lock:
             self.listing[ref.name] = ref
 
-        # update children cache in parent object in case it is not in there already
-        if ref.parent and ref.name not in ref.parent.children:
-            ref.parent.children.append(ref.name)
-            self.logger.debug("Added child \"%s\" to parent \"%s\"", ref.name, ref.parent.name)
-
         # perform filesystem operations
         if save and self.api.is_cobblerd:
             # Save just this item if possible, if not, save the whole collection
@@ -445,8 +416,15 @@ class Collection:
                     # we don't need openvz containers to be network bootable
                     if ref.virt_type == "openvz":
                         ref.enable_menu = False
-                    self.lite_sync.add_single_profile(ref.name)
-                    self.api.sync_systems(systems=ref.get_children())
+                    self.lite_sync.add_single_profile(ref)
+                    self.api.sync_systems(
+                        systems=self.find(
+                            "system",
+                            return_list=True,
+                            no_errors=False,
+                            **{"profile": ref.name},
+                        )
+                    )
                 elif isinstance(ref, distro.Distro):
                     self.lite_sync.add_single_distro(ref.name)
                 elif isinstance(ref, image.Image):

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -69,7 +69,7 @@ class Distros(collection.Collection):
 
         kernel = obj.kernel
         if recursive:
-            kids = obj.get_children()
+            kids = self.api.find_items("profile", {"distro": obj.name})
             for k in kids:
                 self.api.remove_profile(k, recursive=recursive, delete=with_delete, with_triggers=with_triggers)
 

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -58,7 +58,7 @@ class Images(collection.Collection):
                     raise CX(f"removal would orphan system: {system.name}")
 
         if recursive:
-            kids = obj.get_children()
+            kids = self.api.find_items("system", {"image": obj.name})
             for k in kids:
                 self.api.remove_system(k, recursive=True)
 

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Union, Dict, Any
 from cobbler.cexceptions import CX
 from cobbler import serializer
 from cobbler import validate
+from cobbler.settings import Settings
 from cobbler.cobbler_collections.distros import Distros
 from cobbler.cobbler_collections.files import Files
 from cobbler.cobbler_collections.images import Images
@@ -201,6 +202,8 @@ class CollectionManager:
 
         :raises CX: if there is an error in deserialization
         """
+        old_cache_enabled = self.api.settings().cache_enabled
+        self.api.settings().cache_enabled = False
         for collection in (
             self._menus,
             self._distros,
@@ -214,12 +217,27 @@ class CollectionManager:
         ):
             try:
                 serializer.deserialize(collection)
-            except Exception as e:
-                raise CX("serializer: error loading collection %s: %s. Check /etc/cobbler/modules.conf"
-                         % (collection.collection_type(), e)) from e
+            except Exception as error:
+                raise CX(
+                    f"serializer: error loading collection {collection.collection_type()}: {error}."
+                    f"Check your settings!"
+                ) from error
+        self.api.settings().cache_enabled = old_cache_enabled
 
-    def get_items(self, collection_type: str) -> Union[Distros, Profiles, Systems, Repos, Images, Mgmtclasses, Packages,
-                                                       Files, Menus]:
+    def get_items(
+        self, collection_type: str
+    ) -> Union[
+        Distros,
+        Profiles,
+        Systems,
+        Repos,
+        Images,
+        Mgmtclasses,
+        Packages,
+        Files,
+        Menus,
+        Settings,
+    ]:
         """
         Get a full collection of a single type.
 
@@ -240,6 +258,7 @@ class CollectionManager:
             Packages,
             Files,
             Menus,
+            Settings,
         ]
         if validate.validate_obj_type(collection_type) and hasattr(
             self, f"_{collection_type}s"

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -62,20 +62,29 @@ class Menus(collection.Collection):
         :raises CX: Raised in case you want to delete a none existing menu.
         """
         obj = self.find(name=name)
-        if obj is None:
-            raise CX("cannot delete an object that does not exist: %s" % name)
+        if obj is None or not isinstance(obj, menu.Menu):
+            raise CX(f"cannot delete an object that does not exist: {name}")
 
-        for profile in self.api.profiles():
-            if profile.menu and profile.menu == name:
-                profile.menu = ""
-        for image in self.api.images():
-            if image.menu and image.menu == name:
-                image.menu = ""
+        for item_type in ["image", "profile"]:
+            items = self.api.find_items(item_type, {"menu": obj.name}, return_list=True)
+            if items is None:
+                continue
+            if not isinstance(items, list):
+                raise ValueError("Expected list or None from find_items!")
+            for item in items:
+                item.menu = ""
 
         if recursive:
-            kids = obj.get_children()
+            kids = obj.descendants
+            kids.sort(key=lambda x: -x.depth)
             for kid in kids:
-                self.remove(kid, with_delete=with_delete, with_sync=False, recursive=recursive)
+                self.api.remove_item(
+                    kid.COLLECTION_TYPE,
+                    kid,
+                    recursive=False,
+                    delete=with_delete,
+                    with_triggers=with_triggers,
+                )
 
         if with_delete:
             if with_triggers:

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -62,22 +62,21 @@ class Profiles(collection.Collection):
             raise CX("cannot delete an object that does not exist: %s" % name)
 
         if recursive:
-            kids = obj.get_children()
+            kids = obj.descendants
+            kids.sort(key=lambda x: -x.depth)
             for k in kids:
-                if self.api.find_profile(name=k) is not None:
-                    self.api.remove_profile(k, recursive=recursive, delete=with_delete, with_triggers=with_triggers)
-                else:
-                    self.api.remove_system(k, recursive=recursive, delete=with_delete, with_triggers=with_triggers)
+                self.api.remove_item(
+                    k.COLLECTION_TYPE,
+                    k,
+                    recursive=False,
+                    delete=with_delete,
+                    with_triggers=with_triggers,
+                )
 
         if with_delete:
             if with_triggers:
                 utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/profile/pre/*", [])
 
-        if obj.parent is not None and obj.name in obj.parent.children:
-            obj.parent.children.remove(obj.name)
-            # ToDo: Only serialize parent object, use:
-            #       Use self.collection_mgr.serialize_one_item(obj.parent)
-            self.api.serialize()
 
         self.lock.acquire()
         try:

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -69,11 +69,6 @@ class Systems(collection.Collection):
                 lite_sync = self.api.get_sync()
                 lite_sync.remove_single_system(name)
 
-        if obj.parent is not None and obj.name in obj.parent.children:
-            obj.parent.children.remove(obj.name)
-            # ToDo: Only serialize parent object, use:
-            #       Use self.collection_mgr.serialize_one_item(obj.parent)
-            self.api.serialize()
 
         self.lock.acquire()
         try:

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -48,6 +48,9 @@ class Distro(item.Item):
         :param kwargs: Place for extra parameters in this distro object.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._tree_build_time = 0.0
         self._arch = enums.Archs.X86_64
         self._boot_loaders: Union[list, str] = enums.VALUE_INHERITED
@@ -64,6 +67,8 @@ class Distro(item.Item):
         self._remote_boot_initrd = ""
         self._remote_grub_initrd = ""
         self._supported_boot_loaders = []
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __getattr__(self, name):
         if name == "ks_meta":
@@ -473,22 +478,3 @@ class Distro(item.Item):
         if not isinstance(management_key, str):
             raise TypeError("Field redhat_management_key of object distro needs to be of type str!")
         self._redhat_management_key = management_key
-
-    @property
-    def children(self) -> list:
-        """
-        This property represents all children of a distribution. It should not be set manually.
-
-        :getter: The children of the distro.
-        :setter: No validation is done because this is a Cobbler internal property.
-        """
-        return self._children
-
-    @children.setter
-    def children(self, value: list):
-        """
-        Setter for the children property.
-
-        :param value: The new children of the distro.
-        """
-        self._children = value

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -42,7 +42,12 @@ class File(resource.Resource):
         :param kwargs: The keyword arguments which should be passed additionally to a Resource.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._is_dir = False
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -44,6 +44,9 @@ class Image(item.Item):
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._arch = enums.Archs.X86_64
         self._autoinstall = enums.VALUE_INHERITED
         self._breed = ""
@@ -59,9 +62,11 @@ class Image(item.Item):
         self._virt_disk_driver = enums.VirtDiskDrivers.RAW
         self._virt_file_size = enums.VALUE_INHERITED
         self._virt_path = ""
-        self._virt_ram = 0
-        self._virt_type = enums.VirtType.AUTO
+        self._virt_ram: Union[str, int] = enums.VALUE_INHERITED
+        self._virt_type: Union[str, enums.VirtType] = enums.VirtType.INHERITED
         self._supported_boot_loaders = []
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __getattr__(self, name):
         if name == "kickstart":
@@ -551,22 +556,3 @@ class Image(item.Item):
             self._boot_loaders = boot_loaders_split
         else:
             self._boot_loaders = []
-
-    @property
-    def children(self) -> list:
-        """
-        This property represents all children of an image. It should not be set manually.
-
-        :getter: The children of the image.
-        :setter: No validation is done because this is a Cobbler internal property.
-        """
-        return self._children
-
-    @children.setter
-    def children(self, value: list):
-        """
-        Setter for the children property.
-
-        :param value: The new children of the distro.
-        """
-        self._children = value

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -17,7 +17,7 @@ import logging
 import pprint
 import re
 import uuid
-from typing import Any, List, Type, Union, Dict
+from typing import Any, Dict, List, Type, Union, Tuple, Optional
 
 import yaml
 
@@ -28,6 +28,68 @@ from cobbler.decorator import InheritableProperty, InheritableDictProperty
 RE_OBJECT_NAME = re.compile(r'[a-zA-Z0-9_\-.:]*$')
 
 
+class ItemCache:
+    """
+    A Cobbler ItemCache object.
+    """
+
+    def __init__(self, api):
+        """
+        Constructor
+
+        Generalized parameterized cache format:
+           cache_key        cache_value
+         {(P1, P2, .., Pn): value}
+        where P1, .., Pn are cache parameters
+
+        Parameterized cache for to_dict(resolved: bool).
+        The values of the resolved parameter are the key for the Dict.
+        In the to_dict case, there is only one cache parameter and only two key values:
+         {True:  cache_value or None,
+          False: cache_value or None}
+        """
+        self._cached_dict: Dict[bool, Optional[Dict]] = {True: None, False: None}
+
+        self.api = api
+        self.settings = api.settings()
+
+    def get_dict_cache(self, resolved: bool) -> Optional[Dict]:
+        """
+        Gettinging the dict cache.
+
+        :param resolved: "resolved" parameter for Item.to_dict().
+        :return: The cache value for the object, or None if not set.
+        """
+        if self.settings.cache_enabled:
+            return self._cached_dict[resolved]
+        return None
+
+    def set_dict_cache(self, value: Optional[Dict], resolved: bool):
+        """
+        Setter for the dict cache.
+
+        :param value: Sets the value for the dict cache.
+        :param resolved: "resolved" parameter for Item.to_dict().
+        """
+        if self.settings.cache_enabled:
+            self._cached_dict[resolved] = value
+
+    def clean_dict_cache(self):
+        """
+        Cleaninig the dict cache.
+        """
+        if self.settings.cache_enabled:
+            self.set_dict_cache(None, True)
+            self.set_dict_cache(None, False)
+
+    def clean_cache(self):
+        """
+        Cleaninig the Item cache.
+        """
+        if self.settings.cache_enabled:
+            self.clean_dict_cache()
+
+
 class Item:
     """
     An Item is a serializable thing that can appear in a Collection
@@ -36,6 +98,72 @@ class Item:
     TYPE_NAME = "generic"
     COLLECTION_TYPE = "generic"
     CHILD_TYPES = []
+
+    # Item types dependencies.
+    # Used to determine descendants and cache invalidation.
+    # Format: {"Item Type": [("Dependent Item Type", "Dependent Type attribute"), ..], [..]}
+    TYPE_DEPENDENCIES: Dict[str, List[Tuple[str, str]]] = {
+        "package": [
+            ("mgmtclass", "packages"),
+        ],
+        "file": [
+            ("mgmtclass", "files"),
+            ("image", "file"),
+        ],
+        "mgmtclass": [
+            ("distro", "mgmt_classes"),
+            ("profile", "mgmt_classes"),
+            ("system", "mgmt_classes"),
+        ],
+        "repo": [
+            ("profile", "repos"),
+        ],
+        "distro": [
+            ("profile", "distro"),
+        ],
+        "menu": [
+            ("menu", "parent"),
+            ("image", "menu"),
+            ("profile", "menu"),
+        ],
+        "profile": [
+            ("profile", "parent"),
+            ("system", "profile"),
+        ],
+        "image": [
+            ("system", "image"),
+        ],
+        "system": [],
+    }
+
+    # Defines a logical hierarchy of Item Types.
+    # Format: {"Item Type": [("Previous level Type", "Attribute to go to the previous level",), ..],
+    #                       [("Next level Item Type", "Attribute to move from the next level"), ..]}
+    LOGICAL_INHERITANCE: Dict[
+        str, Tuple[List[Tuple[str, str]], List[Tuple[str, str]]]
+    ] = {
+        "distro": (
+            [],
+            [
+                ("profile", "distro"),
+            ],
+        ),
+        "profile": (
+            [
+                ("distro", "distro"),
+            ],
+            [
+                ("system", "profile"),
+            ],
+        ),
+        "image": (
+            [],
+            [
+                ("system", "image"),
+            ],
+        ),
+        "system": ([("image", "image"), ("profile", "profile")], []),
+    }
 
     @classmethod
     def __find_compare(cls, from_search: Union[str, list, dict, bool], from_obj: Union[str, list, dict, bool]):
@@ -89,6 +217,25 @@ class Item:
 
             raise TypeError("find cannot compare type: %s" % type(from_obj))
 
+    @staticmethod
+    def __is_dict_key(name) -> bool:
+        """
+        Whether the attribute is part of the item's to_dict or not
+
+        :name: The attribute name.
+        """
+        return (
+            name.startswith("_")
+            and "__" not in name
+            and name
+            not in {
+                "_last_cached_mtime",
+                "_cache",
+                "_supported_boot_loaders",
+                "_has_initialized",
+            }
+        )
+
     def __init__(self, api, is_subobject: bool = False):
         """
         Constructor.  Requires a back reference to the CobblerAPI object.
@@ -104,6 +251,8 @@ class Item:
                                profile
                                     profile  <-- created with is_subobject=True
                                          system   <-- created as normal
+                           menu
+                               menu
 
         For consistency, there is some code supporting this in all object types, though it is only usable
         (and only should be used) for profiles at this time.  Objects that are children of
@@ -113,9 +262,11 @@ class Item:
         :param api: The Cobbler API object which is used for resolving information.
         :param is_subobject: See above extensive description.
         """
-        self._parent = ''
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
+        self._parent = ""
         self._depth = 0
-        self._children = []
         self._ctime = 0.0
         self._mtime = 0.0
         self._uid = uuid.uuid4().hex
@@ -129,15 +280,15 @@ class Item:
         self._template_files = {}
         self._last_cached_mtime = 0
         self._owners: Union[list, str] = enums.VALUE_INHERITED
-        self._cached_dict: Dict[bool, Any] = {True: None, False: None}
-        self._cached_dict_valid = False
-        self._mgmt_classes: Union[list, str] = []
+        self._cache: ItemCache = ItemCache(api)
+        self._mgmt_classes: Union[list, str] = enums.VALUE_INHERITED
         self._mgmt_parameters: Union[dict, str] = {}
-        self._conceptual_parent = None
         self._is_subobject = is_subobject
 
         self.logger = logging.getLogger()
         self.api = api
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __eq__(self, other):
         """
@@ -150,6 +301,14 @@ class Item:
             return self._uid == other.uid
         return False
 
+    def __hash__(self):
+        """
+        Hash table for Items.
+
+        :return: hash(uid).
+        """
+        return hash(self._uid)
+
     def __setattr__(self, name, value):
         """
         Intercepting an attempt to assign a value to an attribute.
@@ -157,39 +316,9 @@ class Item:
         :name: The attribute name.
         :value: The attribute value.
         """
-        if (
-            name.startswith("_")
-            and not name.startswith("__")
-            and name
-            not in (
-                "_conceptual_parent",
-                "_last_cached_mtime",
-                "_cached_dict",
-                "_cached_dict_valid",
-                "_supported_boot_loaders",
-            )
-        ):
-            # Avoid recursive call to __setattr__
-            self._cached_dict_valid = False
-#            self._invalidate_to_dict_cache()
+        if self.__is_dict_key(name) and self._has_initialized:
+            self.clean_cache(name)
         super().__setattr__(name, value)
-
-    def _invalidate_to_dict_cache(self):
-         self.__dict__["_cached_dict"] = {True: None, False: None}
-         # If this item was invalidated, we need to invalidate children
-         # and parents
-         if hasattr(self, "children"):
-             for child in self.children:
-                 child = self.api.find_items(what="", name=child)
-                 if child:
-                     child.__dict__["_cached_dict"] = {True: None, False: None}
-         self.__invalidate_parents_to_dict_cache(self)
-
-    def __invalidate_parents_to_dict_cache(self, node):
-        if not hasattr(node, "parent") or not node.parent:
-            return
-        node.parent.__dict__["_cached_dict"] = {True: None, False: None}
-        self.__invalidate_parents_to_dict_cache(node.parent)
 
     def _resolve(self, property_name: str) -> Any:
         """
@@ -216,9 +345,10 @@ class Item:
         settings = self.api.settings()
 
         if attribute_value == enums.VALUE_INHERITED:
-            if self.parent is not None and hasattr(self.parent, property_name):
-                return getattr(self.parent, property_name)
-            elif hasattr(settings, settings_name):
+            logical_parent = self.logical_parent
+            if logical_parent is not None and hasattr(logical_parent, property_name):
+                return getattr(logical_parent, property_name)
+            if hasattr(settings, settings_name):
                 return getattr(settings, settings_name)
             elif hasattr(settings, "default_%s" % settings_name):
                 return getattr(settings, "default_%s" % settings_name)
@@ -252,9 +382,10 @@ class Item:
                 isinstance(attribute_value, enums.ConvertableEnum)
                 and attribute_value.value == enums.VALUE_INHERITED
         ):
-            if self.parent is not None and hasattr(self.parent, property_name):
-                return getattr(self.parent, property_name)
-            elif hasattr(settings, settings_name):
+            logical_parent = self.logical_parent
+            if logical_parent is not None and hasattr(logical_parent, property_name):
+                return getattr(logical_parent, property_name)
+            if hasattr(settings, settings_name):
                 return enum_type.to_enum(getattr(settings, settings_name))
             elif hasattr(settings, "default_%s" % settings_name):
                 return enum_type.to_enum(
@@ -286,8 +417,9 @@ class Item:
 
         merged_dict = {}
 
-        if self.parent is not None and hasattr(self.parent, property_name):
-            merged_dict.update(getattr(self.parent, property_name))
+        logical_parent = self.logical_parent
+        if logical_parent is not None and hasattr(logical_parent, property_name):
+            merged_dict.update(getattr(logical_parent, property_name))
         elif hasattr(settings, property_name):
             merged_dict.update(getattr(settings, property_name))
 
@@ -295,7 +427,6 @@ class Item:
             merged_dict.update(attribute_value)
 
         utils.dict_annihilate(merged_dict)
-
         return merged_dict
 
     @property
@@ -674,15 +805,17 @@ class Item:
         self._mtime = mtime
 
     @property
-    def parent(self):
+    def parent(self) -> Any:
         """
-        This property contains the name of the logical parent of an object. In case there is not parent this return
+        This property contains the name of the parent of an object. In case there is not parent this return
         None.
 
         :getter: Returns the parent object or None if it can't be resolved via the Cobbler API.
         :setter: The name of the new logical parent.
         """
-        return None
+        if self._parent is None or self._parent == "":
+            return None
+        return self.api.get_items(self.COLLECTION_TYPE).get(self._parent)
 
     @parent.setter
     def parent(self, parent: str):
@@ -691,37 +824,95 @@ class Item:
 
         :param parent: The new parent object. This needs to be a descendant in the logical inheritance chain.
         """
+        if not isinstance(parent, str):
+            raise TypeError('Property "parent" must be of type str!')
+        if not parent:
+            self._parent = ""
+            return
+        if parent == self.name:
+            # check must be done in two places as setting parent could be called before/after setting name...
+            raise CX("self parentage is weird")
+        found = self.api.get_items(self.COLLECTION_TYPE).get(parent)
+        if found is None:
+            raise CX(f'profile "{parent}" not found, inheritance not possible')
+        self._parent = parent
+        self.depth = found.depth + 1
+
+    def get_parent(self) -> str:
+        """
+        This method returns the name of the parent for the object. In case there is not parent this return
+        empty string.
+        """
+        return self._parent
+
+    def get_conceptual_parent(self) -> Any:
+        """
+        The parent may just be a superclass for something like a subprofile. Get the first parent of a different type.
+
+        :return: The first item which is conceptually not from the same type.
+        """
+        if self is None:
+            return None
+
+        curr_obj = self
+        next_obj = curr_obj.parent
+        while next_obj is not None:
+            curr_obj = next_obj
+            next_obj = next_obj.parent
+
+        if curr_obj.TYPE_NAME in curr_obj.LOGICAL_INHERITANCE:
+            for prev_level in curr_obj.LOGICAL_INHERITANCE[curr_obj.TYPE_NAME][0]:
+                prev_level_type = prev_level[0]
+                prev_level_name = getattr(curr_obj, "_" + prev_level[1])
+                if prev_level_name is not None and prev_level_name != "":
+                    prev_level_item = self.api.find_items(
+                        prev_level_type, name=prev_level_name, return_list=False
+                    )
+                    if prev_level_item is not None:
+                        return prev_level_item
+        return None
 
     @property
-    def children(self) -> List[str]:
+    def logical_parent(self) -> Any:
         """
-        The list of logical children of any depth.
+        This property contains the name of the logical parent of an object. In case there is not parent this return
+        None.
+
+        :getter: Returns the parent object or None if it can't be resolved via the Cobbler API.
+        :setter: The name of the new logical parent.
+        """
+        parent = self.parent
+        if parent is None:
+            return self.get_conceptual_parent()
+        return parent
+
+    @property
+    def children(self) -> List[Any]:
+        """
+        The list of children of the same type.
 
         :getter: An empty list in case of items which don't have logical children.
         :setter: Replace the list of children completely with the new provided one.
         """
-        return []
+        results = []
+        list_items = self.api.get_items(self.COLLECTION_TYPE)
+        for obj in list_items:
+            if obj.get_parent() == self._name:
+                results.append(obj)
+        return results
 
-    @children.setter
-    def children(self, value):
+    def tree_walk(self) -> List[Any]:
         """
-        This is an empty setter to not throw on setting it accidentally.
+        Get all children related by parent/child relationship.
 
-        :param value: The list with children names to replace the current one with.
+        :return: The list of children objects.
         """
-        self.logger.warning("Tried to set the children property on object \"%s\" without logical children.", self.name)
+        results = []
+        for child in self.children:
+            results.append(child)
+            results.extend(child.tree_walk())
 
-    def get_children(self, sort_list: bool = False) -> List[str]:
-        """
-        Get the list of children names.
-
-        :param sort_list: If the list should be sorted alphabetically or not.
-        :return: A copy of the list of children names.
-        """
-        result = copy.deepcopy(self.children)
-        if sort_list:
-            result.sort()
-        return result
+        return results
 
     @property
     def descendants(self) -> list:
@@ -732,17 +923,18 @@ class Item:
 
         :getter: This is a list of all descendants. May be empty if none exist.
         """
-        descendants = []
-        for child in self.children:
-            # different types with same name are possible
-            for child_type in self.CHILD_TYPES:
-                child_object = self.api.find_items(what=child_type, name=child, return_list=False)
-                # child_object is self -> infinite recursion
-                if child_object and child_object is not self:
-                    descendants.append(child_object)
-                    descendants.extend(child_object.descendants)
-
-        return descendants
+        childs = self.tree_walk()
+        results = set(childs)
+        childs.append(self)
+        for child in childs:
+            for item_type in Item.TYPE_DEPENDENCIES[child.COLLECTION_TYPE]:
+                dep_type_items = self.api.find_items(
+                    item_type[0], {item_type[1]: child.name}
+                )
+                results.update(dep_type_items)
+                for dep_item in dep_type_items:
+                    results.update(dep_item.descendants)
+        return list(results)
 
     @property
     def is_subobject(self) -> bool:
@@ -765,22 +957,6 @@ class Item:
         if not isinstance(value, bool):
             raise TypeError("Field is_subobject of object item needs to be of type bool!")
         self._is_subobject = value
-
-    def get_conceptual_parent(self):
-        """
-        The parent may just be a superclass for something like a subprofile. Get the first parent of a different type.
-
-        :return: The first item which is conceptually not from the same type.
-        """
-        mtype = type(self)
-        parent = self.parent
-        while parent is not None:
-            ptype = type(parent)
-            if mtype != ptype:
-                self._conceptual_parent = parent
-                return parent
-            parent = parent.parent
-        return None
 
     def sort_key(self, sort_fields: list):
         """
@@ -918,6 +1094,8 @@ class Item:
             dictionary.pop("ks_meta")
         if "kickstart" in dictionary:
             dictionary.pop("kickstart")
+        if "children" in dictionary:
+            dictionary.pop("children")
 
     def from_dict(self, dictionary: dict):
         """
@@ -949,18 +1127,13 @@ class Item:
                      objects raw value.
         :return: A dictionary with all values present in this object.
         """
-        # We check if cached dict exists and that children list has not changed.
-        # If children list has changed, we need to recalculate the dict.
-        if self._cached_dict[resolved] and self._cached_dict_valid and self._cached_dict[resolved]["children"] == self.children:
-            return self._cached_dict[resolved]
-        elif self._cached_dict[resolved] and not self._cached_dict_valid:
-            self._invalidate_to_dict_cache()
+        cached_result = self.cache.get_dict_cache(resolved)
+        if cached_result is not None:
+            return cached_result
 
         value = {}
-        for key in self.__dict__:
-            if key.startswith("_") and not key.startswith("__"):
-                if key in ("_conceptual_parent", "_last_cached_mtime", "_cached_dict", "_cached_dict_valid", "_supported_boot_loaders"):
-                    continue
+        for key, key_value in self.__dict__.items():
+            if self.__is_dict_key(key):
                 new_key = key[1:].lower()
                 key_value = self.__dict__[key]
                 if isinstance(key_value, enum.Enum):
@@ -991,8 +1164,7 @@ class Item:
             value.update({"kickstart": value["autoinstall"]})
         if "autoinstall_meta" in value:
             value.update({"ks_meta": value["autoinstall_meta"]})
-        self._cached_dict[resolved] = value
-        self._cached_dict_valid = True
+        self.cache.set_dict_cache(value, resolved)
         return value
 
     def serialize(self) -> dict:
@@ -1024,10 +1196,10 @@ class Item:
                  itself and the settings of Cobbler.
         """
         results = [self]
-        parent = self.parent
+        parent = self.logical_parent
         while parent is not None:
             results.append(parent)
-            parent = parent.parent
+            parent = parent.logical_parent
             # FIXME: Now get the object and check its existence
         results.append(self.api.settings())
         self.logger.debug(
@@ -1035,3 +1207,49 @@ class Item:
             len(results),
         )
         return results
+
+    @property
+    def cache(self) -> ItemCache:
+        """
+        Gettinging the ItemCache oject.
+
+        .. note:: This is a read only property.
+
+        :getter: This is the ItemCache oject.
+        """
+        return self._cache
+
+    def _clean_dict_cache(self, name: Optional[str]):
+        """
+        Clearing the Item dict cache.
+
+        :param obj: The object whose modification invalidates the dict cache.
+                    Can be Item, Settings or SIGNATURE_CACHE.
+        :param name: The name of Item attribute or None.
+        """
+        if not self.api.settings().cache_enabled:
+            return
+
+        if name is not None:
+            attr = getattr(type(self), name[1:])
+            if (
+                isinstance(attr, (InheritableProperty, InheritableDictProperty))
+                and self.COLLECTION_TYPE != Item.COLLECTION_TYPE
+                and self.api.get_items(self.COLLECTION_TYPE).get(self.name) is not None
+            ):
+                # Invalidating "resolved" caches
+                for dep_item in self.descendants:
+                    dep_item.cache.set_dict_cache(None, True)
+
+        # Invalidating the cache of the object itself.
+        self.cache.clean_dict_cache()
+
+    def clean_cache(self, name: Optional[str] = None):
+        """
+        Clearing the Item cache.
+
+        :param obj: The object whose modification invalidates the dict cache.
+                    Can be Item, Settings or SIGNATURE_CACHE.
+        :param name: The name of Item attribute or None.
+        """
+        self._clean_dict_cache(name)

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -29,15 +29,20 @@ class Menu(item.Item):
     A Cobbler menu object.
     """
 
+    TYPE_NAME = "menu"
     COLLECTION_TYPE = "menu"
-    CHILD_TYPES = ["menu"]
 
     def __init__(self, api, *args, **kwargs):
         """
         Constructor
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._display_name = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)
@@ -63,76 +68,6 @@ class Menu(item.Item):
         """
         self._remove_depreacted_dict_keys(dictionary)
         super().from_dict(dictionary)
-
-    @property
-    def parent(self) -> Optional['Menu']:
-        """
-        Parent menu of a menu instance.
-
-        :getter: The menu object or None.
-        :setter: Sets the parent.
-        """
-        if not self._parent:
-            return None
-        return self.api.menus().find(name=self._parent)
-
-    @parent.setter
-    def parent(self, value: str):
-        """
-        Setter for the parent menu of a menu.
-
-        :param value: The name of the parent to set.
-        :raises CX: Raised in case of self parenting or if the menu with value ``value`` is not found.
-        """
-        old_parent = self._parent
-        if isinstance(old_parent, item.Item):
-            old_parent.children.remove(self.name)
-        if not value:
-            self._parent = ""
-            return
-        if value == self.name:
-            # check must be done in two places as the parent setter could be called before/after setting the name...
-            raise CX("self parentage is weird")
-        found = self.api.menus().find(name=value)
-        if found is None:
-            raise CX("menu %s not found" % value)
-        self._parent = value
-        self.depth = found.depth + 1
-        new_parent = self._parent
-        if isinstance(new_parent, item.Item) and self.name not in new_parent.children:
-            new_parent.children.append(self.name)
-
-    @property
-    def children(self) -> list:
-        """
-        Child menu of a menu instance.
-
-        :getter: Returns the children.
-        :setter: Sets the children. Raises a TypeError if children have the wrong type.
-        """
-        return self._children
-
-    @children.setter
-    def children(self, value: List[str]):
-        """
-        Setter for the children.
-
-        :param value: The value to set the children to.
-        :raises TypeError: Raised in case the children of menu have the wrong type.
-        """
-        if not isinstance(value, list):
-            raise TypeError("Field children of object menu must be of type list.")
-        if isinstance(value, list):
-            if not all(isinstance(x, str) for x in value):
-                raise TypeError("Field children of object menu must be of type list and all items need to be menu "
-                                "names (str).")
-            self._children = []
-            for name in value:
-                menu = self.api.find_menu(name=name)
-                if menu is not None:
-                    self._children.append(name)
-                else:
-                    self.logger.warning("Menu with the name \"%s\" did not exist. Skipping setting as a child!", name)
 
     #
     # specific methods for item.Menu

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -41,11 +41,16 @@ class Mgmtclass(item.Item):
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._is_definition = False
         self._params = {}
         self._class_name = ""
         self._files = []
         self._packages = []
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -39,8 +39,13 @@ class Package(resource.Resource):
         :param kwargs: The keyword arguments which should be passed additionally to a Resource.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._installer = ""
         self._version = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -35,7 +35,6 @@ class Profile(item.Item):
 
     TYPE_NAME = "profile"
     COLLECTION_TYPE = "profile"
-    CHILD_TYPES = ["profile", "system", "image"]
 
     def __init__(self, api, *args, **kwargs):
         """
@@ -45,6 +44,9 @@ class Profile(item.Item):
         :param kwargs:
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._template_files = {}
         self._autoinstall = enums.VALUE_INHERITED
         self._boot_loaders: Union[list, str] = enums.VALUE_INHERITED
@@ -83,6 +85,8 @@ class Profile(item.Item):
         # Use setters to validate settings
         self.virt_disk_driver = api.settings().default_virt_disk_driver
         self.virt_type = api.settings().default_virt_type
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __getattr__(self, name):
         if name == "kickstart":
@@ -141,57 +145,6 @@ class Profile(item.Item):
     #
 
     @property
-    def parent(self) -> Optional[item.Item]:
-        r"""
-        Instead of a ``--distro``, set the parent of this object to another profile and use the values from the parent
-        instead of this one where the values for this profile aren't filled in, and blend them together where they
-        are dictionaries. Basically this enables profile inheritance. To use this, the object MUST have been
-        constructed with ``is_subobject=True`` or the default values for everything will be screwed up and this will
-        likely NOT work. So, API users -- make sure you pass ``is_subobject=True`` into the constructor when using this.
-
-        Return object next highest up the tree. If this property is not set it falls back to the value of the
-        ``distro``. In case neither distro nor parent is set, it returns None (which would make the profile invalid).
-
-        :getter: The parent object which can be either another profile, a distro or None in case the object could not be
-                 resolved.
-        :setter: The name of the parent object. Might throw a ``CX`` in case the object could not be found.
-        """
-        if not self._parent:
-            parent = self.distro
-            if parent is None:
-                return None
-            return parent
-        else:
-            result = self.api.profiles().find(name=self._parent)
-        return result
-
-    @parent.setter
-    def parent(self, parent: str):
-        r"""
-        Setter for the ``parent`` property.
-
-        :param parent: The name of the parent object.
-        :raises CX: In case self parentage is found or the profile given could not be found.
-        """
-        old_parent = self.parent
-        if isinstance(old_parent, item.Item) and self.name in old_parent.children:
-            old_parent.children.remove(self.name)
-        if not parent:
-            self._parent = ''
-            return
-        if parent == self.name:
-            # check must be done in two places as setting parent could be called before/after setting name...
-            raise CX("self parentage is weird")
-        found = self.api.profiles().find(name=parent)
-        if found is None:
-            raise CX('profile "%s" not found, inheritance not possible' % parent)
-        self._parent = parent
-        self.depth = found.depth + 1
-        new_parent = self.parent
-        if isinstance(new_parent, item.Item) and self.name not in new_parent.children:
-            new_parent.children.append(self.name)
-
-    @property
     def arch(self):
         """
         This represents the architecture of a profile. It is read only.
@@ -199,8 +152,8 @@ class Profile(item.Item):
         :getter: ``None`` or the parent architecture.
         """
         # FIXME: This looks so wrong. It cries: Please open a bug for me!
-        parent = self.parent
-        if parent:
+        parent = self.logical_parent
+        if parent is not None:
             return parent.arch
         return None
 
@@ -232,13 +185,8 @@ class Profile(item.Item):
         distro = self.api.distros().find(name=distro_name)
         if distro is None:
             raise ValueError('distribution "%s" not found' % distro_name)
-        old_parent = self.parent
-        if isinstance(old_parent, item.Item) and self.name in old_parent.children:
-            old_parent.children.remove(self.name)
         self._distro = distro_name
         self.depth = distro.depth + 1    # reset depth if previously a subprofile and now top-level
-        if self.name not in distro.children:
-            distro.children.append(self.name)
 
     @InheritableProperty
     def name_servers(self) -> list:
@@ -463,10 +411,15 @@ class Profile(item.Item):
         """
         if not isinstance(filename, str):
             raise TypeError("Field filename of object profile needs to be of type str!")
+        parent = self.parent
+        if filename == enums.VALUE_INHERITED and parent is None:
+            filename = ""
         if not filename:
-            self._filename = enums.VALUE_INHERITED
-        else:
-            self._filename = filename.strip()
+            if parent:
+                filename = enums.VALUE_INHERITED
+            else:
+                filename = ""
+        self._filename = filename
 
     @property
     def autoinstall(self) -> str:
@@ -740,6 +693,8 @@ class Profile(item.Item):
             boot_loaders_split = utils.input_string_or_list(boot_loaders)
 
             parent = self.parent
+            if parent is None:
+                parent = self.distro
             if parent is not None:
                 parent_boot_loaders = parent.boot_loaders
             else:
@@ -780,20 +735,20 @@ class Profile(item.Item):
         self._menu = menu
 
     @property
-    def children(self) -> list:
+    def display_name(self) -> str:
         """
-        This property represents all children of a distribution. It should not be set manually.
+        Returns the display name.
 
-        :getter: The children of the distro.
-        :setter: No validation is done because this is a Cobbler internal property.
+        :getter: Returns the display name for the boot menu.
+        :setter: Sets the display name for the boot menu.
         """
-        return self._children
+        return self._display_name
 
-    @children.setter
-    def children(self, value: list):
+    @display_name.setter
+    def display_name(self, display_name: str):
         """
-        Setter for the children property.
+        Setter for the display_name of the item.
 
-        :param value: The new children of the distro.
+        :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
         """
-        self._children = value
+        self._display_name = display_name

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -43,6 +43,9 @@ class Repo(item.Item):
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._breed = enums.RepoBreeds.NONE
         self._arch = enums.RepoArchs.NONE
         self._environment = {}
@@ -59,6 +62,8 @@ class Repo(item.Item):
         self._proxy = enums.VALUE_INHERITED
         self._rpm_list = []
         self._os_version = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/resource.py
+++ b/cobbler/items/resource.py
@@ -32,12 +32,17 @@ class Resource(item.Item):
         Constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._action = enums.ResourceAction.CREATE
         self._mode = ""
         self._owner = ""
         self._group = ""
         self._path = ""
         self._template = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -744,6 +744,9 @@ class System(Item):
         :param api: The Cobbler API
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._interfaces: Dict[str, NetworkInterface] = {}
         self._ipv6_autoconfiguration = False
         self._repos_enabled = False
@@ -792,6 +795,8 @@ class System(Item):
         self._kernel_options_post = enums.VALUE_INHERITED
         self._mgmt_parameters = enums.VALUE_INHERITED
         self._mgmt_classes = enums.VALUE_INHERITED
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __getattr__(self, name):
         if name == "kickstart":
@@ -827,55 +832,6 @@ class System(Item):
             self.image = dictionary["image"]
         self._remove_depreacted_dict_keys(dictionary)
         super().from_dict(dictionary)
-
-    @property
-    def parent(self) -> Optional[Item]:
-        """
-        Return object next highest up the tree. This may be a profile or an image.
-
-        :getter: Returns the value for ``parent``.
-        :setter: Sets the value for the property ``parent``.
-        :returns: None when there is no parent or the corresponding Item.
-        """
-        if not self._parent and self.profile:
-            return self.api.profiles().find(name=self.profile)
-        elif not self._parent and self.image:
-            return self.api.images().find(name=self.image)
-        elif self._parent:
-            # We don't know what type this is, so we need to let find_items() do the magic of guessing that.
-            return self.api.find_items(what="", name=self._parent, return_list=False)
-        else:
-            return None
-
-    @parent.setter
-    def parent(self, value: str):
-        r"""
-        Setter for the ``parent`` property.
-
-        :param value: The name of a profile, an image or another System.
-        :raises TypeError: In case value was not of type ``str``.
-        :raises ValueError: In case the specified name does not map to an existing profile, image or system.
-        """
-        if not isinstance(value, str):
-            raise TypeError("The name of the parent must be of type str.")
-        if not value:
-            self._parent = ""
-            return
-        # FIXME: Add an exists method so we don't need to play try-catch here.
-        try:
-            self.api.systems().find(name=value)
-        except ValueError:
-            pass
-        try:
-            self.api.profiles().find(name=value)
-        except ValueError:
-            pass
-        try:
-            self.api.images().find(name=value)
-        except ValueError as value_error:
-            raise ValueError("Neither a system, profile or image could be found with the name \"%s\"."
-                             % value) from value_error
-        self._parent = value
 
     def check_if_valid(self):
         """
@@ -1056,7 +1012,7 @@ class System(Item):
         else:
             boot_loaders_split = boot_loaders
 
-        parent = self.parent
+        parent = self.logical_parent
         if parent is not None:
             parent_boot_loaders = parent.boot_loaders
         else:
@@ -1472,29 +1428,9 @@ class System(Item):
                 'Profile with the name "%s" is not existing' % profile_name
             )
 
-        old_parent = self.parent
-        if isinstance(old_parent, Item):
-            if self.name in old_parent.children:
-                old_parent.children.remove(self.name)
-            else:
-                self.logger.debug(
-                    'Name of System "%s" was not found in the children of Item "%s"',
-                    self.name,
-                    self.parent.name,
-                )
-        else:
-            self.logger.debug(
-                'Parent of System "%s" not found. Thus skipping removal from children list.',
-                self.name,
-            )
-
         self.image = ""  # mutual exclusion rule
-
         self._profile = profile_name
         self.depth = profile.depth + 1  # subprofiles have varying depths.
-        new_parent = self.parent
-        if isinstance(new_parent, Item) and self.name not in new_parent.children:
-            new_parent.children.append(self.name)
 
     @property
     def image(self) -> str:
@@ -1528,29 +1464,9 @@ class System(Item):
         if img is None:
             raise ValueError('Image with the name "%s" is not existing' % image_name)
 
-        old_parent = self.parent
-        if isinstance(old_parent, Item):
-            if self.name in old_parent.children:
-                old_parent.children.remove(self.name)
-            else:
-                self.logger.debug(
-                    'Name of System "%s" was not found in the children of Item "%s"',
-                    self.name,
-                    self.parent.name,
-                )
-        else:
-            self.logger.debug(
-                'Parent of System "%s" not found. Thus skipping removal from children list.',
-                self.name,
-            )
-
         self.profile = ""  # mutual exclusion rule
-
         self._image = image_name
         self.depth = img.depth + 1
-        new_parent = self.parent
-        if isinstance(new_parent, Item) and self.name not in new_parent.children:
-            new_parent.children.append(self.name)
 
     @InheritableProperty
     def virt_cpus(self) -> int:
@@ -2017,27 +1933,6 @@ class System(Item):
         :param baud_rate:
         """
         self._serial_baud_rate = validate.validate_serial_baud_rate(baud_rate)
-
-    @property
-    def children(self) -> List[str]:
-        """
-        children property.
-
-        :getter: Returns the value for ``children``.
-        :setter: Sets the value for the property ``children``.
-        :return:
-        """
-        return [c.name for c in self._children]
-
-    @children.setter
-    def children(self, value: List[str]):
-        """
-        Setter for the children of the System class.
-
-
-        :param value:
-        """
-        self._children = value
 
     def get_config_filename(self, interface: str, loader: Optional[str] = None):
         """

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1997,6 +1997,7 @@ class CobblerXMLRPCInterface:
             return 1
 
         setattr(self.api.settings(), setting_name, value)
+        self.api.clean_items_cache(self.api.settings())
         self.api.settings().save()
         return 0
 

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -179,6 +179,7 @@ class Settings:
         self.windows_enabled = False
         self.windows_template_dir = "/etc/cobbler/windows"
         self.samba_distro_share = "DISTRO"
+        self.cache_enabled = False
 
     def to_string(self) -> str:
         """

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -401,14 +401,10 @@ class TFTPGen:
         :param arch: The processor architecture to generate the menu items for. (Optional)
         """
         if menu:
-            child_names = menu.get_children(sort_list=True)
-            childs = []
-            for child in child_names:
-                child = self.api.find_menu(name=child)
-                if child is not None:
-                    childs.append(child)
+            childs = menu.children
         else:
-            childs = [child for child in self.menus if child.parent is None]
+            childs = self.api.find_items("menu", {"parent": ""})
+        childs.sort(key=lambda child: child.name)
 
         nested_menu_items = {}
         menu_labels = {}
@@ -446,13 +442,14 @@ class TFTPGen:
         :param metadata: Pass additional parameters to the ones being collected during the method.
         :param arch: The processor architecture to generate the menu items for. (Optional)
         """
-        if menu:
-            profile_list = [profile for profile in self.profiles if profile.menu == menu.name]
-        else:
-            profile_list = [profile for profile in self.profiles if profile.menu is None or profile.menu == ""]
-        profile_list = sorted(profile_list, key=lambda profile: profile.name)
+        menu_name = ""
+        if menu is not None:
+            menu_name = menu.name
+        profile_filter = {"menu": menu_name}
         if arch:
-            profile_list = [profile for profile in profile_list if profile.arch == arch]
+            profile_filter["arch"] = arch.value
+        profile_list = self.api.find_items("profile", profile_filter)
+        profile_list.sort(key=lambda profile: profile.name)
 
         current_menu_items = {}
         menu_labels = metadata["menu_labels"]
@@ -496,10 +493,13 @@ class TFTPGen:
         :param metadata: Pass additional parameters to the ones being collected during the method.
         :param arch: The processor architecture to generate the menu items for. (Optional)
         """
-        if menu:
-            image_list = [image for image in self.images if image.menu == menu.name]
-        else:
-            image_list = [image for image in self.images if image.menu is None or image.menu == ""]
+        menu_name = ""
+        if menu is not None:
+            menu_name = menu.name
+        image_filter = {"menu": menu_name}
+        if arch:
+            image_filter["arch"] = arch.value
+        image_list = self.api.find_items("image", image_filter)
         image_list = sorted(image_list, key=lambda image: image.name)
 
         current_menu_items = metadata["menu_items"]

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -570,6 +570,10 @@ puppet_version: 2
 signature_path: "/var/lib/cobbler/distro_signatures.json"
 signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
 
+# Set to true to cache of some internal operations can speed up their execution, but can slow down
+# editing objects.
+cache_enabled: true
+
 # Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
 # this file.
 include: [ "/etc/cobbler/settings.d/*.settings" ]

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -1177,3 +1177,10 @@ Choices:
 - managers.in_tftpd -- default, uses the system's TFTP server
 
 default: ``managers.in_tftpd``
+
+cache_enabled
+#############
+
+If set to ``True``, allows the results of some internal operations to be cached, but may slow down editing of objects.
+
+default: ``True``

--- a/setup.py
+++ b/setup.py
@@ -513,8 +513,15 @@ if __name__ == "__main__":
             "schema"
         ],
         extras_require={
-            "lint": ["pyflakes", "pycodestyle"],
-            "test": ["pytest", "pytest-cov", "codecov", "pytest-mock"]
+            "lint": ["pyflakes", "pycodestyle", "pylint", "black", "mypy"],
+            "test": [
+                "pytest>6",
+                "pytest-cov",
+                "codecov",
+                "pytest-mock",
+                "pytest-benchmark",
+            ],
+            "docs": ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-apidoc"],
         },
         packages=find_packages(exclude=["*tests*"]),
         scripts=[
@@ -741,6 +748,7 @@ if __name__ == "__main__":
             ("%s/tests/test_data/V3_3_3" % datadir, glob("tests/test_data/V3_3_3/*")),
             ("%s/tests/test_data/V3_3_3/settings.d" % datadir, glob("tests/test_data/V3_3_3/settings.d/*")),
             ("%s/tests/xmlrpcapi" % datadir, glob("tests/xmlrpcapi/*.py")),
+            (f"{datadir}/tests/performance", glob("tests/performance/*.py")),
             # tests containers subpackage
             ("%s/docker" % datadir, glob("docker/*")),
             ("%s/docker/debs" % datadir, glob("docker/debs/*")),

--- a/tests/autoinstallation_manager_test.py
+++ b/tests/autoinstallation_manager_test.py
@@ -30,6 +30,7 @@ def api_mock():
     settings_mock.default_name_servers = []
     settings_mock.default_name_servers_search = []
     settings_mock.default_virt_disk_driver = "raw"
+    settings_mock.cache_enabled = False
     api_mock.settings.return_value = settings_mock
     test_distro = Distro(api_mock)
     test_distro.name = "test"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,14 +76,20 @@ def create_kernel_initrd(create_testfile):
 @pytest.fixture(scope="function")
 def create_distro(request, cobbler_api, create_kernel_initrd, fk_kernel, fk_initrd):
     """
-    Returns a function which has no arguments. The function returns a distro object. The distro is already added to
+    Returns a function which has the distro name as an argument. The function returns a distro object. The distro is already added to
     the CobblerAPI.
     """
 
-    def _create_distro():
+    def _create_distro(name="") -> Distro:
         test_folder = create_kernel_initrd(fk_kernel, fk_initrd)
-        test_distro = Distro(cobbler_api)
-        test_distro.name = request.node.originalname if request.node.originalname else request.node.name
+        test_distro = cobbler_api.new_distro()
+        test_distro.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
+        if name != "":
+            test_distro.name = name
         test_distro.kernel = os.path.join(test_folder, fk_kernel)
         test_distro.initrd = os.path.join(test_folder, fk_initrd)
         cobbler_api.add_distro(test_distro)
@@ -95,14 +101,23 @@ def create_distro(request, cobbler_api, create_kernel_initrd, fk_kernel, fk_init
 @pytest.fixture(scope="function")
 def create_profile(request, cobbler_api):
     """
-    Returns a function which has the distro name as an argument. The function returns a profile object. The profile is
+    Returns a function which has the distro or profile name as an argument. The function returns a profile object. The profile is
     already added to the CobblerAPI.
     """
 
-    def _create_profile(distro_name):
-        test_profile = Profile(cobbler_api)
-        test_profile.name = request.node.originalname if request.node.originalname else request.node.name
-        test_profile.distro = distro_name
+    def _create_profile(distro_name="", profile_name="", name="") -> Profile:
+        test_profile = cobbler_api.new_profile()
+        test_profile.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
+        if name != "":
+            test_profile.name = name
+        if profile_name == "":
+            test_profile.distro = distro_name
+        else:
+            test_profile.parent = profile_name
         cobbler_api.add_profile(test_profile)
         return test_profile
 
@@ -112,13 +127,19 @@ def create_profile(request, cobbler_api):
 @pytest.fixture(scope="function")
 def create_image(request, cobbler_api):
     """
-    Returns a function which has no arguments. The function returns an image object. The image is already added to the
+    Returns a function which has the image name as an argument. The function returns an image object. The image is already added to the
     CobblerAPI.
     """
 
-    def _create_image():
-        test_image = Image(cobbler_api)
-        test_image.name = request.node.originalname if request.node.originalname else request.node.name
+    def _create_image(name: str = "") -> Image:
+        test_image = cobbler_api.new_image()
+        test_image.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
+        if name != "":
+            test_image.name = name
         cobbler_api.add_image(test_image)
         return test_image
 

--- a/tests/items/cache_test.py
+++ b/tests/items/cache_test.py
@@ -1,0 +1,781 @@
+import os
+
+import pytest
+
+# from cobbler import enums
+from cobbler.items.package import Package
+from cobbler.items.file import File
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.repo import Repo
+from cobbler.items.distro import Distro
+from cobbler.items.menu import Menu
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+from cobbler.items.item import Item
+from cobbler.settings import Settings
+from tests.conftest import does_not_raise
+from cobbler.cexceptions import CX
+from cobbler.decorator import InheritableProperty, InheritableDictProperty
+
+
+def test_collection_types(cobbler_api):
+    # Arrange
+    mgr = cobbler_api._collection_mgr
+
+    # Act
+    result = mgr.__dict__.items()
+
+    # Assert
+    print(result)
+    assert len(result) == 10
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_package_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_package = Package(cobbler_api)
+    test_package.name = "test_package"
+    cobbler_api.add_package(test_package)
+
+    # Act
+    with expected_exception:
+        result1 = test_package.to_dict(resolved=True)
+        result2 = test_package.to_dict(resolved=False)
+        cached_result1 = test_package.cache.get_dict_cache(True)
+        cached_result2 = test_package.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_file_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_file = File(cobbler_api)
+    test_file.name = "test_file"
+    test_file.path = "test path"
+    test_file.owner = "test owner"
+    test_file.group = "test group"
+    test_file.mode = "test mode"
+    test_file.is_dir = True
+    cobbler_api.add_file(test_file)
+
+    # Act
+    with expected_exception:
+        result1 = test_file.to_dict(resolved=True)
+        result2 = test_file.to_dict(resolved=False)
+        cached_result1 = test_file.cache.get_dict_cache(True)
+        cached_result2 = test_file.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_mgmtclass_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_mgmtclass = Mgmtclass(cobbler_api)
+    test_mgmtclass.name = "test_mgmtclass"
+    cobbler_api.add_mgmtclass(test_mgmtclass)
+
+    # Act
+    with expected_exception:
+        result1 = test_mgmtclass.to_dict(resolved=True)
+        result2 = test_mgmtclass.to_dict(resolved=False)
+        cached_result1 = test_mgmtclass.cache.get_dict_cache(True)
+        cached_result2 = test_mgmtclass.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_repo_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_repo = Repo(cobbler_api)
+    test_repo.name = "test_repo"
+    cobbler_api.add_repo(test_repo)
+
+    # Act
+    with expected_exception:
+        result1 = test_repo.to_dict(resolved=True)
+        result2 = test_repo.to_dict(resolved=False)
+        cached_result1 = test_repo.cache.get_dict_cache(True)
+        cached_result2 = test_repo.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_distro_dict_cache_load(
+    cobbler_api, create_distro, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+
+    # Act
+    with expected_exception:
+        result1 = test_distro.to_dict(resolved=True)
+        result2 = test_distro.to_dict(resolved=False)
+        cached_result1 = test_distro.cache.get_dict_cache(True)
+        cached_result2 = test_distro.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_image_dict_cache_load(
+    cobbler_api, create_image, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_image = create_image()
+
+    # Act
+    with expected_exception:
+        result1 = test_image.to_dict(resolved=True)
+        result2 = test_image.to_dict(resolved=False)
+        cached_result1 = test_image.cache.get_dict_cache(True)
+        cached_result2 = test_image.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_menu_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_menu = Menu(cobbler_api)
+    test_menu.name = "test_menu"
+    cobbler_api.add_menu(test_menu)
+
+    # Act
+    with expected_exception:
+        result1 = test_menu.to_dict(resolved=True)
+        result2 = test_menu.to_dict(resolved=False)
+        cached_result1 = test_menu.cache.get_dict_cache(True)
+        cached_result2 = test_menu.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_profile_dict_cache_load(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+
+    # Act
+    with expected_exception:
+        result1 = test_profile.to_dict(resolved=True)
+        result2 = test_profile.to_dict(resolved=False)
+        cached_result1 = test_profile.cache.get_dict_cache(True)
+        cached_result2 = test_profile.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_system_dict_cache_load(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    create_system,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+    test_system = create_system(profile_name=test_profile.name)
+
+    # Act
+    with expected_exception:
+        result1 = test_system.to_dict(resolved=True)
+        result2 = test_system.to_dict(resolved=False)
+        cached_result1 = test_system.cache.get_dict_cache(True)
+        cached_result2 = test_system.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_package_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_package = Package(cobbler_api)
+    test_package.name = "test_package"
+    cobbler_api.add_package(test_package)
+    test_package.to_dict(resolved=True)
+    test_package.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_package.cache.set_dict_cache(test_cache1, True)
+        test_package.cache.set_dict_cache(test_cache2, False)
+        result1 = test_package.cache.get_dict_cache(True)
+        result2 = test_package.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_file_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_file = File(cobbler_api)
+    test_file.name = "test_file"
+    test_file.path = "test path"
+    test_file.owner = "test owner"
+    test_file.group = "test group"
+    test_file.mode = "test mode"
+    test_file.is_dir = True
+    cobbler_api.add_file(test_file)
+    test_file.to_dict(resolved=True)
+    test_file.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_file.cache.set_dict_cache(test_cache1, True)
+        test_file.cache.set_dict_cache(test_cache2, False)
+        result1 = test_file.cache.get_dict_cache(True)
+        result2 = test_file.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_mgmtclass_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_mgmtclass = Mgmtclass(cobbler_api)
+    test_mgmtclass.name = "test_mgmtclass"
+    cobbler_api.add_mgmtclass(test_mgmtclass)
+    test_mgmtclass.to_dict(resolved=True)
+    test_mgmtclass.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_mgmtclass.cache.set_dict_cache(test_cache1, True)
+        test_mgmtclass.cache.set_dict_cache(test_cache2, False)
+        result1 = test_mgmtclass.cache.get_dict_cache(True)
+        result2 = test_mgmtclass.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_repo_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_repo = Repo(cobbler_api)
+    test_repo.name = "test_repo"
+    cobbler_api.add_repo(test_repo)
+    test_repo.to_dict(resolved=True)
+    test_repo.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_repo.cache.set_dict_cache(test_cache1, True)
+        test_repo.cache.set_dict_cache(test_cache2, False)
+        result1 = test_repo.cache.get_dict_cache(True)
+        result2 = test_repo.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_distro_dict_cache_use(
+    cobbler_api, create_distro, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.to_dict(resolved=True)
+    test_distro.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_distro.cache.set_dict_cache(test_cache1, True)
+        test_distro.cache.set_dict_cache(test_cache2, False)
+        result1 = test_distro.cache.get_dict_cache(True)
+        result2 = test_distro.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_image_dict_cache_use(
+    cobbler_api, create_image, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_image = create_image()
+    test_image.to_dict(resolved=True)
+    test_image.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_image.cache.set_dict_cache(test_cache1, True)
+        test_image.cache.set_dict_cache(test_cache2, False)
+        result1 = test_image.cache.get_dict_cache(True)
+        result2 = test_image.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_menu_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_menu = Menu(cobbler_api)
+    test_menu.name = "test_menu"
+    cobbler_api.add_menu(test_menu)
+    test_menu.to_dict(resolved=True)
+    test_menu.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_menu.cache.set_dict_cache(test_cache1, True)
+        test_menu.cache.set_dict_cache(test_cache2, False)
+        result1 = test_menu.cache.get_dict_cache(True)
+        result2 = test_menu.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_profile_dict_cache_use(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+    test_profile.to_dict(resolved=True)
+    test_profile.to_dict(resolved=False)
+    test_cache1 = {"test": True}
+    test_cache2 = {"test": False}
+
+    # Act
+    with expected_exception:
+        test_profile.cache.set_dict_cache(test_cache1, True)
+        test_profile.cache.set_dict_cache(test_cache2, False)
+        result1 = test_profile.cache.get_dict_cache(True)
+        result2 = test_profile.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_system_dict_cache_use(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    create_system,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+    test_system = create_system(profile_name=test_profile.name)
+    test_system.to_dict(resolved=True)
+    test_system.to_dict(resolved=False)
+    test_cache1 = {"test": True}
+    test_cache2 = {"test": False}
+
+    # Act
+    with expected_exception:
+        test_system.cache.set_dict_cache(test_cache1, True)
+        test_system.cache.set_dict_cache(test_cache2, False)
+        result1 = test_system.cache.get_dict_cache(True)
+        result2 = test_system.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,expected_exception,expected_output",
+    [
+        (True, pytest.raises(CX), True),
+        (False, pytest.raises(CX), False),
+    ],
+)
+def test_dict_cache_invalidate(
+    cobbler_api,
+    create_distro,
+    create_image,
+    create_profile,
+    create_system,
+    cache_enabled,
+    expected_exception,
+    expected_output,
+):
+    def validate_caches(test_api, objs, obj_test, dep):
+        for obj in objs:
+            obj.to_dict(resolved=False)
+            obj.to_dict(resolved=True)
+        remain_objs = set(objs) - set(dep)
+        if isinstance(obj_test, Item):
+            remain_objs.remove(obj_test)
+            obj_test.owners = "test"
+            if (
+                obj_test.cache.get_dict_cache(True) is not None
+                or obj_test.cache.get_dict_cache(False) is not None
+            ):
+                return False
+        elif obj_test == test_api.settings():
+            test_api.clean_items_cache(obj_test)
+        elif obj_test == test_api.get_signatures():
+            test_api.signature_update()
+        for obj in dep:
+            if obj.cache.get_dict_cache(True) is not None:
+                return False
+            if obj.cache.get_dict_cache(False) is None:
+                return False
+        for obj in remain_objs:
+            if obj.cache.get_dict_cache(True) is None:
+                return False
+            if obj.cache.get_dict_cache(False) is None:
+                return False
+        return True
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    test_package = Package(cobbler_api)
+    test_package.name = "test_package"
+    cobbler_api.add_package(test_package)
+    objs = [test_package]
+    test_file = File(cobbler_api)
+    test_file.name = "test_file"
+    test_file.path = "test path"
+    test_file.owner = "test owner"
+    test_file.group = "test group"
+    test_file.mode = "test mode"
+    test_file.is_dir = True
+    cobbler_api.add_file(test_file)
+    objs.append(test_file)
+    test_mgmtclass = Mgmtclass(cobbler_api)
+    test_mgmtclass.name = "test_mgmtclass"
+    test_mgmtclass.packages = [test_package.name]
+    test_mgmtclass.files = [test_file.name]
+    cobbler_api.add_mgmtclass(test_mgmtclass)
+    objs.append(test_mgmtclass)
+    test_repo = Repo(cobbler_api)
+    test_repo.name = "test_repo"
+    cobbler_api.add_repo(test_repo)
+    objs.append(test_repo)
+    test_menu1 = Menu(cobbler_api)
+    test_menu1.name = "test_menu1"
+    cobbler_api.add_menu(test_menu1)
+    objs.append(test_menu1)
+    test_menu2 = Menu(cobbler_api)
+    test_menu2.name = "test_menu2"
+    test_menu2.parent = test_menu1.name
+    cobbler_api.add_menu(test_menu2)
+    objs.append(test_menu2)
+    test_distro = create_distro()
+    test_distro.mgmt_classes = test_mgmtclass.name
+    test_distro.source_repos = [test_repo.name]
+    objs.append(test_distro)
+    test_profile1 = create_profile(distro_name=test_distro.name, name="test_profile1")
+    test_profile1.enable_menu = False
+    objs.append(test_profile1)
+    test_profile2 = create_profile(
+        profile_name=test_profile1.name, name="test_profile2"
+    )
+    test_profile2.enable_menu = False
+    test_profile2.menu = test_menu2.name
+    objs.append(test_profile2)
+    test_profile3 = create_profile(
+        profile_name=test_profile1.name, name="test_profile3"
+    )
+    test_profile3.enable_menu = False
+    test_profile3.mgmt_classes = test_mgmtclass.name
+    test_profile3.repos = [test_repo.name]
+    objs.append(test_profile3)
+    test_image = create_image()
+    test_image.menu = test_menu1.name
+    objs.append(test_image)
+    test_system1 = create_system(profile_name=test_profile1.name, name="test_system1")
+    objs.append(test_system1)
+    test_system2 = create_system(image_name=test_image.name, name="test_system2")
+    objs.append(test_system2)
+
+    # Act
+    package_dep = test_package.descendants
+    file_dep = test_file.descendants
+    mgmtclass_dep = test_mgmtclass.descendants
+    repo_dep = test_repo.descendants
+    menu1_dep = test_menu1.descendants
+    menu2_dep = test_menu2.descendants
+    distro_dep = test_distro.descendants
+    profile1_dep = test_profile1.descendants
+    profile2_dep = test_profile2.descendants
+    profile3_dep = test_profile3.descendants
+    image_dep = test_image.descendants
+    system1_dep = test_system1.descendants
+    system2_dep = test_system2.descendants
+
+    settings_dep = objs
+    signatures_dep = [
+        test_distro,
+        test_profile1,
+        test_profile2,
+        test_profile3,
+        test_image,
+        test_system1,
+        test_system2,
+    ]
+
+    # Assert
+    assert (
+        validate_caches(cobbler_api, objs, test_package, package_dep) == expected_output
+    )
+    assert validate_caches(cobbler_api, objs, test_file, file_dep) == expected_output
+    assert (
+        validate_caches(cobbler_api, objs, test_mgmtclass, mgmtclass_dep)
+        == expected_output
+    )
+    assert validate_caches(cobbler_api, objs, test_repo, repo_dep) == expected_output
+    assert validate_caches(cobbler_api, objs, test_menu1, menu1_dep) == expected_output
+    assert validate_caches(cobbler_api, objs, test_menu2, menu2_dep) == expected_output
+    assert (
+        validate_caches(cobbler_api, objs, test_distro, distro_dep) == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_profile1, profile1_dep)
+        == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_profile2, profile2_dep)
+        == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_profile3, profile3_dep)
+        == expected_output
+    )
+    assert validate_caches(cobbler_api, objs, test_image, image_dep) == expected_output
+    assert (
+        validate_caches(cobbler_api, objs, test_system1, system1_dep) == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_system2, system2_dep) == expected_output
+    )
+
+    assert (
+        validate_caches(cobbler_api, objs, cobbler_api.settings(), settings_dep)
+        == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, cobbler_api.get_signatures(), signatures_dep)
+        == expected_output
+    )
+    with expected_exception:
+        cobbler_api.clean_items_cache(True)

--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -384,12 +384,3 @@ def test_supported_boot_loaders(cobbler_api):
     # Assert
     assert isinstance(distro.supported_boot_loaders, list)
     assert distro.supported_boot_loaders == ["grub", "pxe", "ipxe"]
-
-def test_descendants(create_distro, create_profile, create_system):
-    d = create_distro()
-    p = create_profile(d.name)
-    s = create_system(p.name)
-
-    result = d.descendants
-
-    assert result == [p, s]

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -46,7 +46,7 @@ def test_to_dict(cobbler_api, cleanup_to_dict):
     result = profile.to_dict()
 
     # Assert
-    assert len(result) == 44
+    assert len(result) == 43
     assert result["distro"] == "test_to_dict_distro"
 
 
@@ -195,15 +195,45 @@ def test_next_server_v6(cobbler_api):
     assert profile.next_server_v6 == ""
 
 
-def test_filename(cobbler_api):
+@pytest.mark.parametrize(
+    "input_filename,expected_result,is_subitem,expected_exception",
+    [
+        ("", "", False, does_not_raise()),
+        ("", "", True, does_not_raise()),
+        ("<<inherit>>", "", False, does_not_raise()),
+        ("<<inherit>>", "", True, does_not_raise()),
+        ("test", "test", False, does_not_raise()),
+        ("test", "test", True, does_not_raise()),
+        (0, "", True, pytest.raises(TypeError)),
+    ],
+)
+def test_filename(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    input_filename,
+    expected_result,
+    is_subitem,
+    expected_exception,
+):
+    """
+    Assert that a Cobbler Profile can use the Getter and Setter of the filename property correctly.
+    """
     # Arrange
+    test_dist = create_distro()  # type: ignore
     profile = Profile(cobbler_api)
+    profile.name = "filename_test_profile"
+    if is_subitem:
+        test_profile = create_profile(test_dist.name)  # type: ignore
+        profile.parent = test_profile.name  # type: ignore
+    profile.distro = test_dist.name  # type: ignore
 
     # Act
-    profile.filename = "<<inherit>>"
+    with expected_exception:
+        profile.filename = input_filename
 
-    # Assert
-    assert profile.filename == "<<inherit>>"
+        # Assert
+        assert profile.filename == expected_result
 
 
 def test_autoinstall(cobbler_api):

--- a/tests/modules/managers/genders_test.py
+++ b/tests/modules/managers/genders_test.py
@@ -37,6 +37,7 @@ def api_genders_mock():
     settings_mock.manage_genders = True
     settings_mock.jinja2_includedir = ""
     settings_mock.default_virt_disk_driver = "raw"
+    settings_mock.cache_enabled = False
     api_mock = MagicMock(autospec=True, spec=CobblerAPI)
     api_mock.settings.return_value = settings_mock
     test_distro = Distro(api_mock)

--- a/tests/modules/managers/in_tftpd_test.py
+++ b/tests/modules/managers/in_tftpd_test.py
@@ -38,6 +38,7 @@ def api_mock_tftp():
     settings_mock.default_virt_disk_driver = "raw"
     settings_mock.tftpboot_location = "/var/lib/tftpboot"
     settings_mock.webdir = "/srv/www/cobbler"
+    settings_mock.cache_enabled = False
     api_mock_tftp.settings.return_value = settings_mock
     test_distro = Distro(api_mock_tftp)
     test_distro.name = "test"

--- a/tests/modules/managers/isc_test.py
+++ b/tests/modules/managers/isc_test.py
@@ -35,6 +35,7 @@ def api_isc_mock():
     settings_mock.manage_dhcp_v6 = True
     settings_mock.jinja2_includedir = ""
     settings_mock.default_virt_disk_driver = "raw"
+    settings_mock.cache_enabled = False
     api_mock = MagicMock(autospec=True, spec=CobblerAPI)
     api_mock.settings.return_value = settings_mock
     test_distro = Distro(api_mock)

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -1,0 +1,260 @@
+"""
+Module that contains a helper class which supports the performance testsuite. This is not a pytest style fixture but
+rather related pytest-benchmark. Thus the different style in usage.
+"""
+
+from typing import Callable
+from cobbler.api import CobblerAPI
+
+from cobbler.items.package import Package
+from cobbler.items.file import File
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.repo import Repo
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.menu import Menu
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+
+class CobblerTree:
+    """
+    Helper class that defines methods that can be used during benchmark testing.
+    """
+
+    objs_count = 2
+    test_rounds = 1
+    tree_levels = 3
+
+    @staticmethod
+    def create_packages(api: CobblerAPI):
+        """
+        Create a number of packages for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = Package(api)
+            test_item.name = f"test_package_{i}"
+            api.add_package(test_item)
+
+    @staticmethod
+    def create_files(api: CobblerAPI):
+        """
+        Create a number of files for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = File(api)
+            test_item.name = f"test_file_{i}"
+            test_item.path = "test path"
+            test_item.owner = "test owner"
+            test_item.group = "test group"
+            test_item.mode = "test mode"
+            test_item.is_dir = True
+            api.add_file(test_item)
+
+    @staticmethod
+    def create_mgmtclasses(api: CobblerAPI):
+        """
+        Create a number of managemment classes for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = Mgmtclass(api)
+            test_item.name = f"test_mgmtclass_{i}"
+            test_item.package = f"test_package_{i}"
+            test_item.file = f"test_file_{i}"
+            api.add_mgmtclass(test_item)
+
+    @staticmethod
+    def create_repos(api: CobblerAPI):
+        """
+        Create a number of repos for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = Repo(api)
+            test_item.name = f"test_repo_{i}"
+            api.add_repo(test_item)
+
+    @staticmethod
+    def create_distros(api: CobblerAPI, create_distro: Callable[[str], Distro]):
+        """
+        Create a number of distros for benchmark testing. This pairs the distros with the repositories and mgmt classes.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = create_distro(name=f"test_distro_{i}")
+            test_item.source_repos = [f"test_repo_{i}"]
+            test_item.mgmt_classes = [f"test_mgmtclass_{i}"]
+
+    @staticmethod
+    def create_menus(api: CobblerAPI):
+        """
+        Create a number of menus for benchmark testing. Depending on the menu depth this method also adds children for
+        the menus.
+        """
+        for l in range(CobblerTree.tree_levels):
+            for i in range(CobblerTree.objs_count):
+                test_item = Menu(api)
+                test_item.name = f"level_{l}_test_menu_{i}"
+                if l > 0:
+                    test_item.parent = f"level_{l - 1}_test_menu_{i}"
+                else:
+                    test_item.parent = ""
+                api.add_menu(test_item)
+
+    @staticmethod
+    def create_profiles(
+        api: CobblerAPI, create_profile: Callable[[str, str, str], Profile]
+    ):
+        """
+        Create a number of profiles for benchmark testing. Depending on the menu depth this method also pairs the
+        profile with a menu.
+        """
+        for l in range(CobblerTree.tree_levels):
+            for i in range(CobblerTree.objs_count):
+                if l > 0:
+                    test_item = create_profile(
+                        profile_name=f"level_{l - 1}_test_profile_{i}",
+                        name=f"level_{l}_test_profile_{i}",
+                    )
+                else:
+                    test_item = create_profile(
+                        distro_name=f"test_distro_{i}",
+                        name=f"level_{l}_test_profile_{i}",
+                    )
+                test_item.menu = f"level_{l}_test_menu_{i}"
+                test_item.autoinstall = "sample.ks"
+
+    @staticmethod
+    def create_images(api: CobblerAPI, create_image: Callable[[str], Image]):
+        """
+        Create a number of images for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = create_image(name=f"test_image_{i}")
+            test_item.menu = f"level_{CobblerTree.tree_levels - 1}_test_menu_{i}"
+            test_item.autoinstall = "sample.ks"
+
+    @staticmethod
+    def create_systems(
+        api: CobblerAPI, create_system: Callable[[str, str, str], System]
+    ):
+        """
+        Create a number of systems for benchmark testing. Depending on the strategy the system is paired with a profile
+        or image.
+        """
+        for i in range(CobblerTree.objs_count):
+            if i % 2 == 0:
+                test_item = create_system(
+                    name=f"test_system_{i}",
+                    profile_name=f"level_{CobblerTree.tree_levels - 1}_test_profile_{i}",
+                )
+            else:
+                test_item = create_system(
+                    name=f"test_system_{i}", image_name=f"test_image_{i}"
+                )
+
+    @staticmethod
+    def create_all_objs(
+        api: CobblerAPI,
+        create_distro: Callable[[str], Distro],
+        create_profile: Callable[[str, str, str], Profile],
+        create_image: Callable[[str], Image],
+        create_system: Callable[[str, str, str], System],
+    ):
+        """
+        Method that collectively creates all items at the same time.
+        """
+        CobblerTree.create_packages(api)
+        CobblerTree.create_files(api)
+        CobblerTree.create_mgmtclasses(api)
+        CobblerTree.create_repos(api)
+        CobblerTree.create_distros(api, create_distro)
+        CobblerTree.create_menus(api)
+        CobblerTree.create_profiles(api, create_profile)
+        CobblerTree.create_images(api, create_image)
+        CobblerTree.create_systems(api, create_system)
+
+    @staticmethod
+    def remove_packages(api: CobblerAPI):
+        """
+        Method that removes all packages.
+        """
+        for test_item in api.packages():
+            api.remove_package(test_item.name)
+
+    @staticmethod
+    def remove_files(api: CobblerAPI):
+        """
+        Method that removes all files.
+        """
+        for test_item in api.files():
+            api.remove_file(test_item.name)
+
+    @staticmethod
+    def remove_mgmtclasses(api: CobblerAPI):
+        """
+        Method that removes all management classes.
+        """
+        for test_item in api.mgmtclasses():
+            api.remove_mgmtclass(test_item.name)
+
+    @staticmethod
+    def remove_repos(api: CobblerAPI):
+        """
+        Method that removes all repositories.
+        """
+        for test_item in api.repos():
+            api.remove_repo(test_item.name)
+
+    @staticmethod
+    def remove_distros(api: CobblerAPI):
+        """
+        Method that removes all distributions.
+        """
+        for test_item in api.distros():
+            api.remove_distro(test_item.name)
+
+    @staticmethod
+    def remove_menus(api: CobblerAPI):
+        """
+        Method that removes all menus.
+        """
+        while len(api.menus()) > 0:
+            api.remove_menu(list(api.menus())[0], recursive=True)
+
+    @staticmethod
+    def remove_profiles(api: CobblerAPI):
+        """
+        Method that removes all profiles.
+        """
+        while len(api.profiles()) > 0:
+            api.remove_profile(list(api.profiles())[0], recursive=True)
+
+    @staticmethod
+    def remove_images(api: CobblerAPI):
+        """
+        Method that removes all images.
+        """
+        for test_item in api.images():
+            api.remove_image(test_item.name)
+
+    @staticmethod
+    def remove_systems(api: CobblerAPI):
+        """
+        Method that removes all systems.
+        """
+        for test_item in api.systems():
+            api.remove_system(test_item.name)
+
+    @staticmethod
+    def remove_all_objs(api: CobblerAPI):
+        """
+        Method that collectively removes all items at the same time.
+        """
+        CobblerTree.remove_systems(api)
+        CobblerTree.remove_images(api)
+        CobblerTree.remove_profiles(api)
+        CobblerTree.remove_menus(api)
+        CobblerTree.remove_distros(api)
+        CobblerTree.remove_repos(api)
+        CobblerTree.remove_mgmtclasses(api)
+        CobblerTree.remove_files(api)
+        CobblerTree.remove_packages(api)

--- a/tests/performance/deserialize_test.py
+++ b/tests/performance/deserialize_test.py
@@ -1,0 +1,82 @@
+"""
+Test module to assert the performance of deserializing the object tree.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_deserialize(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that benchmarks the file based deserialization process of Cobbler.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (), {}
+
+    def deserialize():
+        # pylint: disable=protected-access
+        CobblerAPI.__shared_state = {}  # pyright: ignore [reportPrivateUsage]
+        CobblerAPI.__has_loaded = False  # pyright: ignore [reportPrivateUsage]
+        api = CobblerAPI()
+        api.deserialize()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        deserialize, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/get_autoinstall_test.py
+++ b/tests/performance/get_autoinstall_test.py
@@ -1,0 +1,74 @@
+"""
+Test module to assert the performance of retrieving an autoinstallation file.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler import autoinstall_manager
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "profile",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        False,
+        True,
+    ],
+)
+def test_get_autoinstall(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    what: str,
+):
+    """
+    Test that asserts if retrieving rendered autoinstallation templates is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_get_autoinstall(api: CobblerAPI, what: str):
+        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(cobbler_api)
+        for test_item in api.get_items(what):
+            if what == "profile":
+                autoinstall_mgr.generate_autoinstall(profile=test_item.name)
+            elif what == "system":
+                autoinstall_mgr.generate_autoinstall(system=test_item.name)
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = False
+
+    # Act
+    result = benchmark.pedantic(
+        item_get_autoinstall, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -1,0 +1,431 @@
+"""
+Test module to assert the performance of adding different kinds of items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_packages_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a package is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_packages, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_files_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a package is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_files, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_mgmtclasses_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a package is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_mgmtclasses, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_repos_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a repository is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_repos, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_distros_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    cache_enabled: bool,
+):
+    """
+    Test that asserts if creating a distro is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_packages(cobbler_api)
+        CobblerTree.create_files(cobbler_api)
+        CobblerTree.create_mgmtclasses(cobbler_api)
+        CobblerTree.create_repos(cobbler_api)
+        return (cobbler_api, create_distro), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_distros, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_menus_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a menu is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_menus, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_profiles_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating a profile is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_packages(cobbler_api)
+        CobblerTree.create_files(cobbler_api)
+        CobblerTree.create_mgmtclasses(cobbler_api)
+        CobblerTree.create_repos(cobbler_api)
+        CobblerTree.create_distros(cobbler_api, create_distro)
+        CobblerTree.create_menus(cobbler_api)
+        return (cobbler_api, create_profile), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_profiles, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_images_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], Image],
+    cache_enabled: bool,
+):
+    """
+    Test that asserts if creating an image is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_menus(cobbler_api)
+        return (cobbler_api, create_image), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_images, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_systems_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating a system is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_packages(cobbler_api)
+        CobblerTree.create_files(cobbler_api)
+        CobblerTree.create_mgmtclasses(cobbler_api)
+        CobblerTree.create_repos(cobbler_api)
+        CobblerTree.create_distros(cobbler_api, create_distro)
+        CobblerTree.create_menus(cobbler_api)
+        CobblerTree.create_images(cobbler_api, create_image)
+        CobblerTree.create_profiles(cobbler_api, create_profile)
+        return (cobbler_api, create_system), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_systems, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_all_items_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating all items at once is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (
+            cobbler_api,
+            create_distro,
+            create_profile,
+            create_image,
+            create_system,
+        ), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_all_objs, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_copy_test.py
+++ b/tests/performance/item_copy_test.py
@@ -1,0 +1,92 @@
+"""
+Test module to assert the performance of copying items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_copy(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    what: str,
+):
+    """
+    Test that asserts if copying an item is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_copy(api: CobblerAPI, what: str):
+        for test_item in api.get_items(what):
+            api.copy_item(what, test_item, test_item.name + "_copy")
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_copy, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -1,0 +1,102 @@
+"""
+Test module to assert the performance of editing items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "inherit_property",
+    [
+        False,
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_edit(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    inherit_property: bool,
+    what: str,
+):
+    """
+    Test that asserts if editing items is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_edit(api: CobblerAPI, what: str):
+        for test_item in api.get_items(what):
+            if inherit_property:
+                test_item.owners = "test owners"
+            else:
+                test_item.comment = "test commect"
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_edit, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_remove_test.py
+++ b/tests/performance/item_remove_test.py
@@ -1,0 +1,92 @@
+"""
+Test module to assert the performance of removing items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_remove(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    what: str,
+):
+    """
+    Test that asserts if removing one or more items is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_remove(api: CobblerAPI, what: str):
+        while len(api.get_items(what)) > 0:
+            api.remove_item(what, list(api.get_items(what))[0], recursive=True)
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_remove, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_rename_test.py
+++ b/tests/performance/item_rename_test.py
@@ -1,0 +1,92 @@
+"""
+Test module to assert the performance of renaming items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_rename(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    what: str,
+):
+    """
+    Test that asserts if renaming an item is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_rename(api: CobblerAPI, what: str):
+        for test_item in api.get_items(what):
+            api.rename_item(what, test_item, test_item.name + "_renamed")
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_rename, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/make_pxe_menu_test.py
+++ b/tests/performance/make_pxe_menu_test.py
@@ -1,0 +1,78 @@
+"""
+Test module to assert the performance of creating the PXE menu.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_make_pxe_menu(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating the PXE menu is running wihtout a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (cobbler_api,), {}
+
+    def make_pxe_menu(api: CobblerAPI):
+        api.tftpgen.make_pxe_menu()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        make_pxe_menu, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/start_test.py
+++ b/tests/performance/start_test.py
@@ -1,0 +1,80 @@
+"""
+Test module to assert the performance of the startup of the daemon.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_start(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if the startup of Cobbler is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (), {}
+
+    def start_cobbler():
+        CobblerAPI.__shared_state = {}
+        CobblerAPI.__has_loaded = False
+        api = CobblerAPI()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        start_cobbler, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/sync_test.py
+++ b/tests/performance/sync_test.py
@@ -1,0 +1,76 @@
+"""
+Test module to assert the performance of "cobbler sync".
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_sync(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if "cobbler sync" without arguments is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (cobbler_api,), {}
+
+    def sync(api: CobblerAPI):
+        api.sync()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(sync, setup=setup_func, rounds=CobblerTree.test_rounds)
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/test_data/V3_3_3/settings.yaml
+++ b/tests/test_data/V3_3_3/settings.yaml
@@ -566,6 +566,10 @@ iso_template_dir: "/etc/cobbler/iso"
 signature_path: "/var/lib/cobbler/distro_signatures.json"
 signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
 
+# A cache of some internal operations can speed up their execution, but can slow down
+# editing objects.
+cache_enabled: true
+
 # Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
 # this file.
 include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]


### PR DESCRIPTION
Backported from https://github.com/cobbler/cobbler/pull/3301

## Linked Items

Partially fixes https://github.com/SUSE/spacewalk/issues/20326

## Description

Use upstream implementation of  Item to_dict cache. Part of the change is that the children property is not stored as an attribute, but computed on access.

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
