### PR TITLE
Use bootloader config parameters in expected order

### DIFF
--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -638,7 +638,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         system_names = utils.input_string_or_list_no_inherit(systems)
         profile_names = utils.input_string_or_list_no_inherit(profiles)
         loader_config_parts = self._generate_boot_loader_configs(
-            system_names, profile_names, exclude_dns
+            profile_names, system_names, exclude_dns
         )
 
         buildisodir = self._prepare_buildisodir(buildisodir)


### PR DESCRIPTION
## Description

Fixes passing parameters to boot loader config generator in correct order - first profiles, then systems.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
