### PR TITLE
suma/4.3: Switch GH action to use new container images based on this branch

### DIFF
--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker pull registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:suma-43
       - name: Run previously built Docker Container
-        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:suma-43
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker pull registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:suma-43
       - name: Run previously built Docker Container
-        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:suma-43
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -32,6 +32,7 @@ RUN zypper install --no-recommends -y \
     gzip                       \
     ipmitool                   \
     make                       \
+    openssl                    \
     python3                    \
     python3-Sphinx             \
     python3-coverage           \

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -1,7 +1,18 @@
 # vim: ft=dockerfile
+#!BuildTag: cobbler-test-github:latest cobbler-test-github:suma-43 cobbler-test-github:suma-43.%RELEASE%
 
 # WARNING! This is not in any way production ready. It is just for testing!
-FROM registry.opensuse.org/opensuse/leap:15.3
+FROM opensuse/leap:15.3
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=org.opensuse.example
+LABEL org.opencontainers.image.title="cobbler-test-github"
+LABEL org.opencontainers.image.description="This contains the environment to run the testsuites of Cobbler inside a container."
+LABEL org.opencontainers.image.version="0.1.0.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/home/cobbler-project/github-ci/cobbler-test-github:suma-43.%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
 
 # ENV Variables we are using.
 ENV container docker
@@ -52,12 +63,9 @@ RUN zypper install --no-recommends -y \
     dosfstools
 
 # Add virtualization repository
-RUN zypper ar https://download.opensuse.org/repositories/Virtualization/15.3/Virtualization.repo
-RUN zypper --gpg-auto-import-keys install -y --from "Virtualization (15.3)" python3-hivex
-RUN zypper rr "Virtualization (15.3)"
-RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/python/15.3/devel:languages:python.repo
-RUN zypper --gpg-auto-import-keys install -y --from "Python Modules (15.3)" python3-pefile
-RUN zypper rr "Python Modules (15.3)"
+RUN zypper install -y \
+    python3-hivex     \
+    python3-pefile
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \
@@ -65,9 +73,9 @@ RUN zypper install --no-recommends -y \
     shim \
     ipxe-bootimgs \
     grub2 \
-    grub2-i386-efi \
-    grub2-x86_64-efi \
-    grub2-arm64-efi
+#    grub2-i386-efi \
+    grub2-x86_64-efi
+#    grub2-arm64-efi
 
 # Required for dhcpd
 RUN zypper install --no-recommends -y \
@@ -76,6 +84,7 @@ RUN zypper install --no-recommends -y \
 
 # Required for ldap tests
 RUN zypper install --no-recommends -y \
+    openssl-1_1                       \
     openldap2                         \
     openldap2-client                  \
     hostname                          \
@@ -94,7 +103,8 @@ RUN zypper install --no-recommends -y \
     perl-Net-INET6Glue                \
     perl-LWP-Protocol-https           \
     ed
-RUN dnf install -y http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/d/debmirror-2.35-2.fc35.noarch.rpm
+# FIXME: We don't have debmirror in the right OBS projects.
+#RUN dnf install -y http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/d/debmirror-2.35-2.fc35.noarch.rpm
 
 # Dependencies for system-tests
 RUN zypper install --no-recommends -y \
@@ -112,19 +122,15 @@ RUN useradd -p $(perl -e 'print crypt("test", "password")') test
 # Add Developer scripts to PATH
 ENV PATH="/code/docker/develop/scripts:${PATH}"
 
-# Update pip
-RUN pip3 install --upgrade pip
-
 # Install packages and dependencies via pip
-RUN pip3 install      \
-    codecov           \
-    file-magic        \
-    pycodestyle       \
-    pyflakes          \
-    pytest            \
-    pytest-cov        \
-    pytest-mock       \
-    pytest-pythonpath
+RUN zypper install --no-recommends -y \
+    python3-codecov            \
+    python3-magic              \
+    python3-pycodestyle        \
+    python3-pyflakes           \
+    python3-pytest             \
+    python3-pytest-cov         \
+    python3-pytest-mock
 
 # Enable the Apache Modules
 RUN ["a2enmod", "version"]

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -1,5 +1,5 @@
 # vim: ft=dockerfile
-#!BuildTag: cobbler-test-github:latest cobbler-test-github:suma-43 cobbler-test-github:suma-43.%RELEASE%
+#!BuildTag: cobbler-test-github:suma-43 cobbler-test-github:suma-43.%RELEASE%
 
 # WARNING! This is not in any way production ready. It is just for testing!
 FROM opensuse/leap:15.3

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -17,6 +17,7 @@ RUN zypper install -y          \
     gzip                       \
     make                       \
     util-linux                 \
+    openssl                    \
     hardlink                   \
     xorriso                    \
     ipmitool                   \


### PR DESCRIPTION
## Description

This PR adjusts the GH actions for `suma/4.3` branch so it uses the new container images built at OBS: 
https://build.opensuse.org/project/show/home:cobbler-project:github-ci

This should fix the current failures we have in our tests due "openssl" issues.

**NOTE: This PR needs to be merged in order for the new images to build successfully in OBS - as the image building requires the changed made in this PR. So it is expected that PR tests for this PR are going to fail**

**Once the PR is merged, the images should be able to build and then available to be used by GH actions**

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
