### PR TITLE
Add dependencies for testing item cache backport

### DIFF
--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -49,6 +49,7 @@ RUN zypper install --no-recommends -y \
     python3-requests           \
     python3-PyYAML             \
     python3-pykickstart        \
+    python3-pytest-benchmark   \
     python3-netaddr            \
     python3-pymongo            \
     rpm-build                  \


### PR DESCRIPTION
I'm building container images in OBS based on this PR: https://build.opensuse.org/package/show/home:agraul:branches:home:cobbler-project:github-ci:suma-43/cobbler-docker-testing

After I locally verified that all dependencies to run the tests are included, I'll merge it.