### PR TITLE
Drop flaky test_descendants test

### DIFF
--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -384,12 +384,3 @@ def test_supported_boot_loaders(cobbler_api):
     # Assert
     assert isinstance(distro.supported_boot_loaders, list)
     assert distro.supported_boot_loaders == ["grub", "pxe", "ipxe"]
-
-def test_descendants(create_distro, create_profile, create_system):
-    d = create_distro()
-    p = create_profile(d.name)
-    s = create_system(p.name)
-
-    result = d.descendants
-
-    assert result == [p, s]


### PR DESCRIPTION
This test sometimes fails in CI and it's not needed anymore, the function is covered by backported tests in 198fd43