### PR TITLE
Backport profile arch find_match fix

### DIFF
--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -140,6 +140,24 @@ class Profile(item.Item):
         self._remove_depreacted_dict_keys(dictionary)
         super().from_dict(dictionary)
 
+    def find_match_single_key(self, data, key, value, no_errors = False):
+        """
+        Look if the data matches or not. This is an alternative for ``find_match()``.
+
+        :param data: The data to search through.
+        :param key: The key to look for int the item.
+        :param value: The value for the key.
+        :param no_errors: How strict this matching is.
+        :return: Whether the data matches or not.
+        """
+        # special case for profile, since arch is a derived property from the parent distro
+        if key == "arch":
+            if self.arch:
+                return self.arch.value == value
+            return value is None
+
+        return super().find_match_single_key(data, key, value, no_errors)
+
     #
     # specific methods for item.Profile
     #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,9 @@ import pytest
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
-from cobbler.items.profile import Profile
 from cobbler.items.image import Image
+from cobbler.items.menu import Menu
+from cobbler.items.profile import Profile
 from cobbler.items.system import NetworkInterface, System
 
 
@@ -168,6 +169,31 @@ def create_system(request, cobbler_api):
         return test_system
 
     return _create_system
+
+
+@pytest.fixture(scope="function")
+def create_menu(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
+    """
+    Returns a function which has the profile name as an argument. The function returns a system object. The system is
+    already added to the CobblerAPI.
+    """
+
+    def _create_menu(name: str = "", display_name: str = "") -> Menu:
+        test_menu = cobbler_api.new_menu()
+
+        if name == "":
+            test_menu.name = (
+                request.node.originalname  # type: ignore
+                if request.node.originalname  # type: ignore
+                else request.node.name
+            )
+
+        test_menu.display_name = display_name
+
+        cobbler_api.add_menu(test_menu)
+        return test_menu
+
+    return _create_menu
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -413,28 +413,51 @@ def test_sort_key(request, cobbler_api):
     assert result == [request.node.originalname if request.node.originalname else request.node.name]
 
 
-@pytest.mark.skip("Test not yet implemented")
-def test_find_match(cobbler_api):
+@pytest.mark.parametrize(
+    "in_keys, check_keys, expect_match",
+    [
+        ({"uid": "test-uid"}, {"uid": "test-uid"}, True),
+        ({"name": "test-object"}, {"name": "test-object"}, True),
+        ({"comment": "test-comment"}, {"comment": "test-comment"}, True),
+        ({"uid": "test-uid"}, {"uid": ""}, False),
+    ],
+)
+def test_find_match(cobbler_api, in_keys, check_keys, expect_match):
+    """
+    Assert that given a desired amount of key-value pairs is matching the item or not.
+    """
+    # Arrange
+    titem = Item(cobbler_api, **in_keys)
+
+    # Act
+    result = titem.find_match(check_keys)
+
+    # Assert
+    assert expect_match == result
+
+
+@pytest.mark.parametrize(
+    "data_keys, check_key, check_value, expect_match",
+    [
+        ({"uid": "test-uid"}, "uid", "test-uid", True),
+        ({"menu": "testmenu0"}, "menu", "testmenu0", True),
+        ({"uid": "test", "name": "test-name"}, "uid", "test", True),
+        ({"depth": "1"}, "name", "test", False),
+        ({"uid": "test", "name": "test-name"}, "menu", "testmenu0", False),
+    ],
+)
+def test_find_match_single_key(cobbler_api, data_keys, check_key, check_value, expect_match):
+    """
+    Assert that a single given key and value match the object or not.
+    """
     # Arrange
     titem = Item(cobbler_api)
 
     # Act
-    titem.find_match()
+    result = titem.find_match_single_key(data_keys, check_key, check_value)
 
     # Assert
-    assert False
-
-
-@pytest.mark.skip("Test not yet implemented")
-def test_find_match_single_key(cobbler_api):
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    titem.find_match_single_key()
-
-    # Assert
-    assert False
+    assert expect_match == result
 
 
 def test_dump_vars(cobbler_api):

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -427,7 +427,8 @@ def test_find_match(cobbler_api, in_keys, check_keys, expect_match):
     Assert that given a desired amount of key-value pairs is matching the item or not.
     """
     # Arrange
-    titem = Item(cobbler_api, **in_keys)
+    titem = Item(cobbler_api)
+    titem.from_dict(in_keys)
 
     # Act
     result = titem.find_match(check_keys)

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -1,3 +1,9 @@
+"""
+Test module to validate the functionallity of the Cobbler Profile item.
+"""
+
+from typing import Any, Callable, Dict, List
+
 import pytest
 
 from cobbler import enums
@@ -441,3 +447,53 @@ def test_menu(cobbler_api):
 
     # Assert
     assert profile.menu == ""
+
+
+def test_display_name(cobbler_api):
+    """
+    Assert that the display name of a Cobbler Profile can be set successfully.
+    """
+    # Arrange
+    profile = Profile(cobbler_api)
+
+    # Act
+    profile.display_name = ""
+
+    # Assert
+    assert profile.display_name == ""
+
+
+@pytest.mark.parametrize(
+    "data_keys, check_key, check_value, expect_match",
+    [
+        ({"uid": "test-uid"}, "uid", "test-uid", True),
+        ({"menu": "testmenu0"}, "menu", "testmenu0", True),
+        ({"uid": "test", "name": "test-name"}, "uid", "test", True),
+        ({"uid": "test"}, "arch", "x86_64", True),
+        ({"uid": "test"}, "arch", "aarch64", False),
+        ({"depth": "1"}, "name", "test", False),
+        ({"uid": "test", "name": "test-name"}, "menu", "testmenu0", False),
+    ],
+)
+def test_find_match_single_key(
+    cobbler_api,
+    create_distro: Callable[[], Distro],
+    data_keys: Dict[str, Any],
+    check_key: str,
+    check_value: Any,
+    expect_match: bool,
+):
+    """
+    Assert that a single given key and value match the object or not.
+    """
+    # Arrange
+    test_distro_obj = create_distro()
+    test_distro_obj.arch = enums.Archs.X86_64
+    profile = Profile(cobbler_api)
+    profile.distro = test_distro_obj.name
+
+    # Act
+    result = profile.find_match_single_key(data_keys, check_key, check_value)
+
+    # Assert
+    assert expect_match == result


### PR DESCRIPTION
After introducing new item caching, there was a problem with special handling of profile.arch, upstream already fixed it, but we are missing backport of the fix.

Backport of https://github.com/cobbler/cobbler/pull/3411

Fixes https://github.com/SUSE/spacewalk/issues/22284