### PR TITLE
uyuni/master: Adjust source for CI containers used in GitHub actions

### DIFF
--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:suma-43
+        run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:uyuni-master
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:suma-43
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:uyuni-master
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:suma-43
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:suma-43
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:uyuni-master
+        run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:uyuni-master
       - name: Run previously built Docker Container
-        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:uyuni-master
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:uyuni-master
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:uyuni-master
+        run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:uyuni-master
       - name: Run previously built Docker Container
-        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:uyuni-master
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:uyuni-master
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |


### PR DESCRIPTION
Backport https://github.com/cobbler/cobbler/pull/3483 to `uyuni/master` branch.

Tracks: https://github.com/SUSE/spacewalk/issues/21785