### PR TITLE
WIP: Cross arch buildiso support with "tftpboot-installation" to "mkloaders" script

### DIFF
--- a/tftpboot-installation-to-mkloaders.sh
+++ b/tftpboot-installation-to-mkloaders.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# two options:
+# 1. copy grub binary
+# 2. copy grub modules and call cobbler mkloaders
+# option 2 is more in line with cobbler and is tried first. if modules are missing and a binary exists, option 1 is used for this architecture
+
+pkgs=$(zypper se tftpboot-installation | awk -F'|' '/tftp installation tree/ {print $2}')
+
+linkOrCopy () {
+	source=$1
+	dest=$(dirname $2)
+	# compare device number of both paths to see if a hardlink is possible
+	if [ $(stat --format=%d $source) -eq $(stat --format=%d $dest) ]
+	then
+		cmd=ln
+	else
+		cmd=cp
+	fi
+	$cmd $source $dest
+}
+
+installIfMissing () {
+	pkg=$1
+	if [ $(rpm -q $pkg) -eq 1 ]
+	then
+		zypper install $pkg
+	fi
+}
+
+containsGrubMods() {
+	rpm -ql $1 | grep hello.mod
+}
+
+for pkg in $pkgs
+do
+	installIfMissing $pkg
+	if containsGrubMods $pkg
+	then
+		# find dir with modules, then copy/link
+	else
+		# copy/link binaries
+done
+
+# it's okay if cobbler replaces copied bootloaders, we just want to make sure we have one per arch
+cobbler mkloaders


### PR DESCRIPTION
This is a spinoff PR from https://github.com/openSUSE/cobbler/pull/67 , in order to separate this possible approach the cross arch buildiso problems out of the context of the other PR.

The problem: the "grub2-xxxx" packages for all different architectures are not available in the OS repositories for a particular architecture. So, "grub2-powerpc-ieee1275" is not available on the "x86_64" repositories. These packages provides necessary boot/grub files to allow "cobbler mkloaders" to prepare necessary bootloaders for the different architectures.

Current approeaches to solve this problem:
- Create script to setup necessary environment based on "tftpboot-installation" packages that are available on each architecture for all different archs.
- Add the missing "grub2-xxxxx" packages to SUSE/Uyuni Server channels, so we have them available in the SRV. This is the approach that we are currently following in the SUMA Proxy, where these packages were added, due to Retail product requirements.

I'm creating this Draft PR here so we can keep the WIP script until we take a decision.