### PR TITLE
Fix package building with Sphinx >= 7.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ doc: ## Creates the documentation with sphinx in html form.
 	@echo "creating: documentation"
 	@cd docs; make html > /dev/null 2>&1
 
+man: ## Creates documentation and man pages using Sphinx
+	@${PYTHON} -m sphinx -b man -j auto ./docs ./build/sphinx/man
+
 qa: ## If pyflakes and/or pycodestyle is found then they are run.
 ifeq ($(strip $(PYFLAKES)),)
 	@echo "No pyflakes found"

--- a/cobbler.changes
+++ b/cobbler.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May  6 10:05:29 UTC 2026 - Pablo Suárez Hernández <pablo.suarezhernandez@suse.com>
+
+- Fix package building with Sphinx >= 7.0.0
+
+-------------------------------------------------------------------
 Tue May  5 14:20:39 UTC 2026 - Pablo Suárez Hernández <pablo.suarezhernandez@suse.com>
 
 - Add support for building with Python 3.13

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -187,6 +187,7 @@ BuildRequires:  apache2-deb-macros
 BuildRequires:  %{py3_module_coverage}
 BuildRequires:  python%{python3_pkgversion}-distro
 BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-netaddr
 BuildRequires:  python%{python3_pkgversion}-schema
 BuildRequires:  python%{python3_pkgversion}-systemd

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -318,6 +318,7 @@ sed -e "s|/var/lib/tftpboot|%{tftpboot_dir}|g" -i config/cobbler/settings.yaml
 [ "${TFTPROOT}" != %{tftpboot_dir} ] && echo "ERROR: TFTPROOT: ${TFTPROOT} does not match %{tftpboot_dir}"
 
 %py3_build
+make man
 
 %install
 . distro_build_configs.sh

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ except ImportError:
 from distutils.command.build import build as _build
 from configparser import ConfigParser
 from setuptools import find_packages
-from sphinx.setup_command import BuildDoc
 
 import codecs
 from coverage import Coverage
@@ -156,15 +155,6 @@ class build(_build):
     def run(self):
         _build.run(self)
 
-#####################################################################
-# # Build man pages using Sphinx  ###################################
-#####################################################################
-
-
-class build_man(BuildDoc):
-    def initialize_options(self):
-        BuildDoc.initialize_options(self)
-        self.builder = 'man'
 
 #####################################################################
 # # Configure files ##################################################
@@ -298,8 +288,7 @@ def has_man_pages(build):
 
 
 build.sub_commands.extend((
-    ('build_man', has_man_pages),
-    ('build_cfg', has_configure_files)
+    ('build_cfg', has_configure_files),
 ))
 
 
@@ -483,7 +472,6 @@ if __name__ == "__main__":
             'savestate': savestate,
             'restorestate': restorestate,
             'build_cfg': build_cfg,
-            'build_man': build_man
         },
         name="cobbler",
         version=VERSION,


### PR DESCRIPTION
Sphinx has dropped the integration with setuptools in version 7.0.0:
https://www.sphinx-doc.org/en/master/changes.html#release-7-0-0-released-apr-29-2023

This removal is currently causing issues when building Cobbler package, as the setup.py script is making use of removed code:

```
[   28s] + /usr/bin/python3 setup.py build '--executable=/usr/bin/python3 -s'
[   28s] Traceback (most recent call last):
[   28s]   File "/home/abuild/rpmbuild/BUILD/cobbler-3.3.3.0+git.5c498dbf/setup.py", line 17, in <module>
[   28s]     from sphinx.setup_command import BuildDoc
[   28s] ModuleNotFoundError: No module named 'sphinx.setup_command'
[   28s] error: Bad exit status from /var/tmp/rpm-tmp.mAzLcE (%build)
```

This PR simply makes documentation and man pages to be built outside of setup.py script. It's also useful to be able to use the testing container for `openSUSE/cobbler`. 

Backport of https://github.com/cobbler/cobbler/pull/3434