### PR TITLE
Docker: Use sysconfig for starting Apache2

### DIFF
--- a/docker/debs/build-and-install-debs.sh
+++ b/docker/debs/build-and-install-debs.sh
@@ -44,6 +44,7 @@ echo "==> Install fresh packages ..."
 $EXECUTOR exec -it cobbler bash -c 'dpkg -i deb-build/DEBS/all/cobbler*.deb'
 
 echo "==> Restart Apache and Cobbler daemon ..."
+$EXECUTOR exec -it cobbler bash -c 'a2enmod proxy && a2enmod proxy_http'
 $EXECUTOR exec -it cobbler bash -c 'a2enconf cobbler'
 
 echo "==> Start Supervisor"

--- a/docker/develop/supervisord/conf.d/httpd.conf
+++ b/docker/develop/supervisord/conf.d/httpd.conf
@@ -1,3 +1,3 @@
 [program:httpd]
-command=/usr/sbin/httpd -D FOREGROUND
+command=/usr/sbin/start_apache2 -DFOREGROUND -k start
 redirect_stderr=true

--- a/docker/rpms/build-and-install-rpms.sh
+++ b/docker/rpms/build-and-install-rpms.sh
@@ -46,6 +46,7 @@ $EXECUTOR run --cap-add=NET_ADMIN -t -d --name cobbler \
 
 echo "==> Install fresh RPMs ..."
 $EXECUTOR exec -t cobbler bash -c 'rpm -Uvh rpm-build/cobbler-*.noarch.rpm'
+$EXECUTOR exec -it cobbler bash -c 'a2enmod proxy && a2enmod proxy_http'
 
 # openSUSE does not have this file so skip it
 if test "${TAG#*opensuse}" == "$TAG"

--- a/docker/rpms/opensuse_leap/supervisord/conf.d/httpd.conf
+++ b/docker/rpms/opensuse_leap/supervisord/conf.d/httpd.conf
@@ -1,3 +1,3 @@
 [program:httpd]
-command=/usr/sbin/httpd -D FOREGROUND
+command=/usr/sbin/start_apache2 -DFOREGROUND -k start
 redirect_stderr=true

--- a/docker/rpms/opensuse_tumbleweed/supervisord/conf.d/httpd.conf
+++ b/docker/rpms/opensuse_tumbleweed/supervisord/conf.d/httpd.conf
@@ -1,3 +1,3 @@
 [program:httpd]
-command=/usr/sbin/httpd -D FOREGROUND
+command=/usr/sbin/start_apache2 -DFOREGROUND -k start
 redirect_stderr=true


### PR DESCRIPTION
Backporting https://github.com/cobbler/cobbler/commit/d96d35a7a315da14c3e85431dd6f97efbfef367c to simplify internal Cobbler test pipeline.