### PR TITLE
suma/4.3: Add uyuni authentication endpoint property

### DIFF
--- a/changelog.d/3631.added
+++ b/changelog.d/3631.added
@@ -1,0 +1,1 @@
+Add new setting for uyuni authentication endpoint

--- a/cobbler/modules/authentication/spacewalk.py
+++ b/cobbler/modules/authentication/spacewalk.py
@@ -94,10 +94,13 @@ def authenticate(api_handle, username: str, password: str) -> bool:
 
     if api_handle is None:
         raise CX("api_handle required. Please don't call this without it.")
-    server = api_handle.settings().redhat_management_server
+    server = "https://" + api_handle.settings().redhat_management_server
+    if api_handle.settings().uyuni_authentication_endpoint:
+        server = api_handle.settings().uyuni_authentication_endpoint
+
     user_enabled = api_handle.settings().redhat_management_permissive
 
-    spacewalk_url = "https://%s/rpc/api" % server
+    spacewalk_url = f"{server}/rpc/api"
     with ServerProxy(spacewalk_url, verbose=True) as client:
         if username == 'taskomatic_user' or __looks_like_a_token(password):
             # The tokens are lowercase hex, but a password can also be lowercase hex, so we have to try it as both a

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -149,6 +149,7 @@ class Settings:
         self.redhat_management_permissive = False
         self.redhat_management_server = "xmlrpc.rhn.redhat.com"
         self.redhat_management_key = ""
+        self.uyuni_authentication_endpoint = ""
         self.register_new_installs = False
         self.remove_old_puppet_certs_automatically = False
         self.replicate_repo_rsync_options = "-avzH"

--- a/cobbler/settings/migrations/V3_3_3.py
+++ b/cobbler/settings/migrations/V3_3_3.py
@@ -197,6 +197,7 @@ schema = Schema(
         "redhat_management_permissive": bool,
         "redhat_management_server": str,
         "redhat_management_key": str,
+        Optional("uyuni_authentication_endpoint"): str,
         "register_new_installs": bool,
         "remove_old_puppet_certs_automatically": bool,
         "replicate_repo_rsync_options": str,

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -390,6 +390,11 @@ nopxe_with_triggers: true
 # authentication within Cobbler Web and Cobbler XMLRPC.
 redhat_management_server: "xmlrpc.rhn.redhat.com"
 
+# This setting is only used by the code that supports using uyuni/SUSE Manager
+# authentication within Cobbler Web and Cobbler XMLRPC. This is the endpoint for 
+# uyuni/SUSE Manager authentication: if empty redhat_management_server will be used.
+uyuni_authentication_endpoint: ""
+
 # if using authn_spacewalk in modules.conf to let Cobbler authenticate
 # against Satellite/Spacewalk's auth system, by default it will not allow per user
 # access into Cobbler Web and Cobbler XMLRPC.

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -846,6 +846,16 @@ Cobbler XML-RPC.
 
 default: ``"xmlrpc.rhn.redhat.com"``
 
+uyuni_authentication_endpoint
+#################################
+
+This setting is only used by the code that supports using uyuni/SUSE Manager authentication within Cobbler Web and Cobbler XMLRPC.
+This is the endpoint for uyuni/SUSE Manager authentication: if empty redhat_management_server will be used.
+
+e.g.: ``uyuni_authentication_endpoint: http://localhost``
+
+default: ``""``
+
 redhat_management_key
 =====================
 

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -471,7 +471,7 @@ def test_dump_vars(cobbler_api):
     # Assert
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 152
+    assert len(result) == 153
 
 
 @pytest.mark.parametrize(

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -262,7 +262,7 @@ def test_blender(cobbler_api):
     result = utils.blender(cobbler_api, False, root_item)
 
     # Assert
-    assert len(result) == 165
+    assert len(result) == 166
     # Must be present because the settings have it
     assert "server" in result
     # Must be present because it is a field of distro


### PR DESCRIPTION
This PR backports https://github.com/openSUSE/cobbler/pull/87 to `suma/4.3` branch