### PR TITLE
Increase start timeout for cobblerd unit

### DIFF
--- a/config/service/cobblerd.service
+++ b/config/service/cobblerd.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/cobblerd -F
 PrivateTmp=yes
 KillMode=process
 Type=notify
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The default timeout when starting the systemd unit is 90s. In this PR, we double it in case users have large number of systems managed by Cobbler. 