### PR TITLE
Increase start timeout for cobblerd unit

### DIFF
--- a/config/service/cobblerd.service
+++ b/config/service/cobblerd.service
@@ -7,6 +7,8 @@ Wants=@@httpd_service@@
 ExecStart=/usr/bin/cobblerd -F
 PrivateTmp=yes
 KillMode=process
+Type=notify
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Porting https://github.com/openSUSE/cobbler/pull/104 to uyuni/stable. Including also `type=notify` from https://github.com/openSUSE/cobbler/blame/f49e0e95d42be6a2edd6b1639b331ee804c729ac/config/service/cobblerd.service (which was probably forgotten to be backported)