### PR TITLE
Set default x86_64 bootloader name to grub.efi

### DIFF
--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -78,6 +78,10 @@ bootloaders_formats:
     extra_modules:
       - chain
       - efinet
+  # Necessary for secure boot to work by default with SUSE-based distros
+  default-suse-efi:
+    binary_name: grub.efi
+    use_secure_boot_grub: true
 bootloaders_modules:
   - btrfs
   - ext2


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1230869

On x86_64, we provide `shim.efi`, which expects `grub.efi`. However, by default, `grub.efi` gets copied as `grubx86.efi`, which means that secure boot doesn't work without modifying the config. 