### PR TITLE
Set default x86_64 bootloader name to grub.efi

### DIFF
--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -78,6 +78,10 @@ bootloaders_formats:
     extra_modules:
       - chain
       - efinet
+  # Necessary for secure boot to work by default with SUSE-based distros
+  default-suse-efi:
+    binary_name: grub.efi
+    use_secure_boot_grub: true
 bootloaders_modules:
   - btrfs
   - ext2


### PR DESCRIPTION
Backporting https://github.com/openSUSE/cobbler/pull/108