### PR TITLE
suma/head: Add cobbler.rpmlintrc as Source to spec file

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -170,6 +170,7 @@ Group:          Development/System
 
 License:        GPL-2.0-or-later
 Source:         %{name}-%{version}.tar.gz
+Source1:        cobbler.rpmlintrc
 BuildArch:      noarch
 
 BuildRequires:  git-core


### PR DESCRIPTION
The spec file we use for building in IBS needs to mention the `cobbler.rpmlintrc` file that is used.