### PR TITLE
Synchronize cobbler add and cobbler sync actions (bsc#1233371)

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1566,9 +1566,9 @@ class CobblerAPI:
                 return
             raise TypeError('Systems must be a list of one or more strings.')
         self.logger.info(
-            "Waiting sync_lock to be available to perform the sync action (this might take some time)"
+            "Waiting lock to be available to perform the sync action (this might take some time)"
         )
-        with utils.filelock("/var/lib/cobbler/sync_lock"):
+        with utils.filelock("/var/lib/cobbler/lock"):
             sync_obj = self.get_sync(verbose=verbose)
             sync_obj.run_sync_systems(systems)
 
@@ -1587,9 +1587,9 @@ class CobblerAPI:
         if not what:
             self.logger.info("syncing all")
             self.logger.info(
-                "Waiting sync_lock to be available to perform the sync action (this might take some time)"
+                "Waiting lock to be available to perform the sync action (this might take some time)"
             )
-            with utils.filelock("/var/lib/cobbler/sync_lock"):
+            with utils.filelock("/var/lib/cobbler/lock"):
                 sync_obj = self.get_sync(verbose=verbose)
                 sync_obj.run()
             return
@@ -1618,9 +1618,9 @@ class CobblerAPI:
         )
         dns = dns_module.get_manager(self)
         self.logger.info(
-            "Waiting sync_lock to be available to perform the sync action (this might take some time)"
+            "Waiting lock to be available to perform the sync action (this might take some time)"
         )
-        with utils.filelock("/var/lib/cobbler/sync_lock"):
+        with utils.filelock("/var/lib/cobbler/lock"):
             dns.sync()
 
     # ==========================================================================
@@ -1640,9 +1640,9 @@ class CobblerAPI:
         )
         dhcp = dhcp_module.get_manager(self)
         self.logger.info(
-            "Waiting sync_lock to be available to perform the sync action (this might take some time)"
+            "Waiting lock to be available to perform the sync action (this might take some time)"
         )
-        with utils.filelock("/var/lib/cobbler/sync_lock"):
+        with utils.filelock("/var/lib/cobbler/lock"):
             dhcp.sync()
 
     # ==========================================================================

--- a/tests/api/sync_test.py
+++ b/tests/api/sync_test.py
@@ -32,7 +32,7 @@ def test_sync(cobbler_api, input_verbose, input_what, expected_exception, mocker
         cobbler_api.sync(input_verbose, input_what)
 
     # Assert
-    assert filelock_mock.called_once_with("/var/lib/cobbler/sync_lock")
+    assert filelock_mock.called_once_with("/var/lib/cobbler/lock")
     if not input_what:
         stub.run.assert_called_once()
     if input_what and "dhcp" in input_what:
@@ -62,7 +62,7 @@ def test_sync_dns(cobbler_api, input_manage_dns, mocker):
     cobbler_api.sync_dns()
 
     # Assert
-    assert filelock_mock.called_once_with("/var/lib/cobbler/sync_lock")
+    assert filelock_mock.called_once_with("/var/lib/cobbler/lock")
     m_property.assert_called_once()
     assert stub.sync.called == input_manage_dns
 
@@ -86,7 +86,7 @@ def test_sync_dhcp(cobbler_api, input_manager_dhcp, mocker):
     cobbler_api.sync_dhcp()
 
     # Assert
-    assert filelock_mock.called_once_with("/var/lib/cobbler/sync_lock")
+    assert filelock_mock.called_once_with("/var/lib/cobbler/lock")
     m_property.assert_called_once()
     assert stub.sync.called == input_manager_dhcp
 
@@ -121,7 +121,7 @@ def test_sync_systems(cobbler_api, input_systems, input_verbose, expected_except
     filelock_mock = mocker.patch("cobbler.utils.filelock")
 
     # Act
-    assert filelock_mock.called_once_with("/var/lib/cobbler/sync_lock")
+    assert filelock_mock.called_once_with("/var/lib/cobbler/lock")
     with expected_exception:
         cobbler_api.sync_systems(input_systems, input_verbose)
 


### PR DESCRIPTION
Cobbler currently has two lock files; one for `cobbler sync`, the other one for everything else. This means that Cobbler sync can run at the same time as when we modify an item in Cobbler, which causes Cobbler to fail.

Relates to: https://github.com/SUSE/spacewalk/issues/25815

Upstream port: https://github.com/cobbler/cobbler/pull/3897