### PR TITLE
Exclude disabled profiles from buildiso gen (bsc#1230908)

### DIFF
--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -180,7 +180,8 @@ class BuildIso:
         """
         if selected_items is None:
             selected_items = []
-        return self.filter_items(self.api.profiles(), selected_items)
+
+        return [profile for profile in self.filter_items(self.api.profiles(), selected_items) if profile.enable_menu]
 
     def filter_items(self, all_objs, selected_items: List[str]) -> list:
         """Return a list of valid profile or system objects selected from all profiles or systems by name, or everything

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -183,6 +183,22 @@ def test_filter_profile(cobbler_api, create_distro, create_profile):
     assert expected_result == result
 
 
+def test_filter_profile_disabled(cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_profile.enable_menu = False
+    itemlist = [test_profile.name]
+    build_iso = buildiso.BuildIso(cobbler_api)
+    expected_result = [] # No enabled profiles
+
+    # Act
+    result = build_iso.filter_profiles(itemlist)
+
+    # Assert
+    assert expected_result == result
+
+
 def test_netboot_run(
     cobbler_api,
     create_distro,


### PR DESCRIPTION
Currently, all profiles are taken into consideration when using `cobbler buildiso` - even if a user explicitly disabled a profile.

With this change, we only use enabled profiles when generating an ISO.