### PR TITLE
uyuni/master: Prevent crash during Cobbler startup on NFS environments (bsc#1240666) 

### DIFF
--- a/changelog.d/3905.fixed
+++ b/changelog.d/3905.fixed
@@ -1,0 +1,1 @@
+Prevent crash during Cobbler startup on NFS environments

--- a/changelog.d/3905.fixed
+++ b/changelog.d/3905.fixed
@@ -1,1 +1,1 @@
-Prevent crash during Cobbler startup on NFS environments
+Prevent crash during Cobbler startup on NFS environments (bsc#1240666)

--- a/cobbler/serializer.py
+++ b/cobbler/serializer.py
@@ -49,7 +49,9 @@ def __grab_lock():
             if not os.path.exists("/var/lib/cobbler/lock"):
                 fd = open("/var/lib/cobbler/lock", "w+")
                 fd.close()
-            LOCK_HANDLE = open("/var/lib/cobbler/lock", "r")
+            # exclusive lock requires writtable mode (r+) on NFS
+            # https://man7.org/linux/man-pages/man2/flock.2.html
+            LOCK_HANDLE = open("/var/lib/cobbler/lock", "r+")
             fcntl.flock(LOCK_HANDLE.fileno(), fcntl.LOCK_EX)
     except:
         # this is pretty much FATAL, avoid corruption and quit now.
@@ -66,7 +68,9 @@ def __release_lock(with_changes=False):
         fd.write("%f" % time.time())
         fd.close()
     if LOCK_ENABLED:
-        LOCK_HANDLE = open("/var/lib/cobbler/lock", "r")
+        # exclusive lock requires writtable mode (r+) on NFS
+        # https://man7.org/linux/man-pages/man2/flock.2.html
+        LOCK_HANDLE = open("/var/lib/cobbler/lock", "r+")
         fcntl.flock(LOCK_HANDLE.fileno(), fcntl.LOCK_UN)
         LOCK_HANDLE.close()
 


### PR DESCRIPTION
This PR backports https://github.com/cobbler/cobbler/pull/3906 to `uyuni/master`

Since Linux 2.6.12, NFS clients support flock() locks by emulating them as fcntl(2) byte-range locks on the entire file.  This means that fcntl(2) and flock() locks do interact with one another over NFS.  It also means that in order to place an exclusive lock, the file must be opened for writing.

https://man7.org/linux/man-pages/man2/flock.2.html