### PR TITLE
suma/4.3: Bump version of github action runner nodes 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint_docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
     - name: Set up Python
@@ -22,7 +22,7 @@ jobs:
     - name: Run doc8
       run: doc8 --ignore D001 docs
   lint_shellscripts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Run ShellCheck

--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_performance_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Pull Docker Test Container

--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_system_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Pull Docker Test Container


### PR DESCRIPTION
To avoid the current message we got on the GH action execution:

```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```