### PR TITLE
Implement transactions

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -296,7 +296,7 @@ class CobblerSync:
 
         self.templar.render(template_data, metadata, "/etc/rsyncd.conf")
 
-    def add_single_distro(self, name):
+    def add_single_distro(self, name, rebuild_menu: bool = True):
         """
         Sync adding a single distro.
 
@@ -331,9 +331,10 @@ class CobblerSync:
         kids = self.api.find_items("profile", {"distro": name}, return_list=True)
         for k in kids:
             self.add_single_profile(k, rebuild_menu=False)
-        self.tftpgen.make_pxe_menu()
+        if rebuild_menu:
+            self.tftpgen.make_pxe_menu()
 
-    def add_single_image(self, name):
+    def add_single_image(self, name, rebuild_menu: bool = True):
         """
         Sync adding a single image.
 
@@ -344,7 +345,8 @@ class CobblerSync:
         kids = self.api.find_items("system", {"image": name})
         for k in kids:
             self.add_single_system(k)
-        self.tftpgen.make_pxe_menu()
+        if rebuild_menu:
+            self.tftpgen.make_pxe_menu()
 
     def remove_single_distro(self, name):
         """

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -26,7 +26,7 @@ import tempfile
 import threading
 from configparser import ConfigParser
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from schema import SchemaError
 
@@ -1005,6 +1005,45 @@ class CobblerAPI:
         self.add_item("menu", ref, check_for_duplicate_names=check_for_duplicate_names, save=save)
 
     # ==========================================================================
+    def add_remove_items(self, items: List[Tuple[str, "Item", bool, float, str]]):
+        """
+        Add or remove multiple items.
+
+        :param items: The list of items.
+        """
+        for what, ref, _, mtime, base_id in items:
+            if base_id:
+                orig_ref = self.find_items(what, criteria={"uid": base_id}, return_list=False)
+                if not orig_ref or isinstance(orig_ref, list) or mtime != orig_ref.mtime:
+                    raise ValueError("The item has been modified")
+
+        to_remove = [i for i in items if i[2]]
+        to_add = [i for i in items if not i[2]]
+
+        to_remove.sort(key=lambda x: -x[1].depth)
+        to_add.sort(key=lambda x: x[1].depth)
+
+        for what, ref, _, _, _ in to_add:
+            self.log(f"add_item({what})", [ref.name])
+            self.get_items(what).add(
+                ref,  # type: ignore
+                check_for_duplicate_names=False,
+                save=True,
+                with_triggers=True,
+                rebuild_menu=False
+            )
+
+        for what, ref, _, _, _ in to_remove:
+            self.log(f"remove_item({what})", [ref.name])
+            self.get_items(what).remove(
+                ref.name,
+                recursive=False,
+                with_delete=True,
+                with_triggers=True,
+                rebuild_menu=False
+            )
+
+        self.tftpgen.make_pxe_menu()
 
     def find_items(self, what: str = "", criteria: dict = None, name: str = "", return_list: bool = True,
                    no_errors: bool = False):

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -84,6 +84,7 @@ class Collection:
         with_sync: bool = True,
         with_triggers: bool = True,
         recursive: bool = False,
+        rebuild_menu: bool = True,
     ) -> None:
         """
         Remove an item from collection. This method must be overridden in any subclass.
@@ -93,6 +94,7 @@ class Collection:
         :param with_sync: sync to server file system
         :param with_triggers: run "on delete" triggers
         :param recursive: recursively delete children
+        :param rebuild_menu: rebuild menu after removing the item
         :returns: NotImplementedError
         """
         raise NotImplementedError("Please implement this in a child class of this class.")
@@ -338,6 +340,7 @@ class Collection:
         with_sync: bool = True,
         quick_pxe_update: bool = False,
         check_for_duplicate_names: bool = False,
+        rebuild_menu: bool = True,
     ):
         """
         Add an object to the collection
@@ -415,7 +418,7 @@ class Collection:
                     # we don't need openvz containers to be network bootable
                     if ref.virt_type == "openvz":
                         ref.enable_menu = False
-                    self.lite_sync.add_single_profile(ref)
+                    self.lite_sync.add_single_profile(ref, rebuild_menu=rebuild_menu)
                     self.api.sync_systems(
                         systems=self.find(
                             "system",
@@ -425,9 +428,9 @@ class Collection:
                         )
                     )
                 elif isinstance(ref, distro.Distro):
-                    self.lite_sync.add_single_distro(ref.name)
+                    self.lite_sync.add_single_distro(ref.name, rebuild_menu=rebuild_menu)
                 elif isinstance(ref, image.Image):
-                    self.lite_sync.add_single_image(ref.name)
+                    self.lite_sync.add_single_image(ref.name, rebuild_menu=rebuild_menu)
                 elif isinstance(ref, repo.Repo):
                     pass
                 elif isinstance(ref, mgmtclass.Mgmtclass):

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -49,7 +49,7 @@ class Distros(collection.Collection):
         return new_distro
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
-               recursive: bool = False):
+               recursive: bool = False, rebuild_menu: bool = True):
         """
         Remove element named 'name' from the collection
 

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -40,7 +40,7 @@ class Images(collection.Collection):
         return new_image
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
-               recursive: bool = True):
+               recursive: bool = True, rebuild_menu: bool = True):
         """
         Remove element named 'name' from the collection
 

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -46,7 +46,7 @@ class Profiles(collection.Collection):
         return new_profile
 
     def remove(self, name: str, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
-               recursive: bool = False):
+               recursive: bool = False, rebuild_menu: bool = True):
         """
         Remove element named 'name' from the collection
 

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -817,21 +817,27 @@ class Item:
         return self.api.get_items(self.COLLECTION_TYPE).get(self._parent)
 
     @parent.setter
-    def parent(self, parent: str):
+    def parent(self, parent: Union["Item", str]):
         """
         Set the parent object for this object.
 
         :param parent: The new parent object. This needs to be a descendant in the logical inheritance chain.
         """
-        if not isinstance(parent, str):
-            raise TypeError('Property "parent" must be of type str!')
+        found = None
+        if isinstance(parent, Item):
+            found = parent
+            parent = parent.name
+        elif not isinstance(parent, str):
+            raise TypeError('Property "parent" must be of type Item or str!')
+
         if not parent:
             self._parent = ""
             return
         if parent == self.name:
             # check must be done in two places as setting parent could be called before/after setting name...
             raise CX("self parentage is weird")
-        found = self.api.get_items(self.COLLECTION_TYPE).get(parent)
+        if found is None:
+            found = self.api.get_items(self.COLLECTION_TYPE).get(parent)
         if found is None:
             raise CX(f'profile "{parent}" not found, inheritance not possible')
         self._parent = parent

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -189,18 +189,23 @@ class Profile(item.Item):
         return self.api.distros().find(name=self._distro)
 
     @distro.setter
-    def distro(self, distro_name: str):
+    def distro(self, distro_name: Union["Distro", str]):
         """
         Sets the distro. This must be the name of an existing Distro object in the Distros collection.
 
         :param distro_name: The name of the distro.
         """
-        if not isinstance(distro_name, str):
-            raise TypeError("distro_name needs to be of type str")
+        distro = None
+        if isinstance(distro_name, Distro):
+            distro = distro_name
+            distro_name = distro.name
+        elif not isinstance(distro_name, str):
+            raise TypeError("distro_name needs to be of type Distro or str")
         if not distro_name:
             self._distro = ""
             return
-        distro = self.api.distros().find(name=distro_name)
+        if distro is None:
+            distro = self.api.distros().find(name=distro_name)
         if distro is None:
             raise ValueError('distribution "%s" not found' % distro_name)
         self._distro = distro_name

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -132,6 +132,9 @@ class CobblerXMLRPCInterface:
         self.logger = logging.getLogger()
         self.token_cache: Dict[str, tuple] = {}
         self.object_cache = {}
+        self.transactions: Dict[
+            str, Dict[str, Tuple[str, "Item", bool, float, str]]
+        ] = {}
         self.timestamp = self.api.last_modified_time()
         self.events = {}
         self.shared_secret = utils.get_shared_secret()
@@ -594,8 +597,6 @@ class CobblerXMLRPCInterface:
             msg = "%s; name(%s)" % (msg, name)
 
         if object_id is not None:
-            if not validate_obj_id(object_id):
-                return
             msg = "%s; object_id(%s)" % (msg, object_id)
 
         # add any attributes being modified, if any
@@ -697,13 +698,18 @@ class CobblerXMLRPCInterface:
             'items_per_page_list': [10, 20, 50, 100, 200, 500],
         })
 
-    def __get_object(self, object_id: str):
+    def __get_object(self, object_id: str, token: Optional[str] = None):
         """
         Helper function. Given an object id, return the actual object.
 
         :param object_id: The id for the object to retrieve.
         :return: The item to the corresponding id.
         """
+        if token and token in self.transactions and object_id in self.transactions[token]:
+            what, obj, removed, mtime, base_id = self.transactions[token][object_id]
+            if removed:
+                raise ValueError("Object has been deleted in current transaction!")
+            return obj
         if object_id.startswith("___NEW___"):
             return self.object_cache[object_id][1]
         (otype, oname) = object_id.split("::", 1)
@@ -761,7 +767,7 @@ class CobblerXMLRPCInterface:
             )
         return return_value
 
-    def get_item(self, what: str, name: str, flatten=False, resolved: bool = False):
+    def get_item(self, what: str, name: str, flatten=False, resolved: bool = False, token = None):
         """
         Returns a dict describing a given object.
 
@@ -772,7 +778,15 @@ class CobblerXMLRPCInterface:
                          objects raw value.
         :return: The item or None.
         """
-        self._log("get_item(%s,%s)" % (what, name))
+        self._log("get_item(%s,%s)" % (what, name), token=token)
+        if token in self.transactions:
+            for handle, (iwhat, item, deleted, mtime, base_id) in self.transactions[token].items():
+                if iwhat == what and item.name == name:
+                    if deleted:
+                        return self.xmlrpc_hacks(None)
+                    else:
+                        return self.xmlrpc_hacks(item.to_dict(resolved=resolved))
+
         requested_item = self.api.get_item(what, name)
         if requested_item is not None:
             requested_item = requested_item.to_dict(resolved=resolved)
@@ -794,7 +808,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("distro", name, flatten=flatten, resolved=resolved)
+        return self.get_item("distro", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_profile(
         self, name: str, flatten=False, resolved: bool = False, token=None, **rest
@@ -810,7 +824,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("profile", name, flatten=flatten, resolved=resolved)
+        return self.get_item("profile", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_system(
         self, name: str, flatten=False, resolved: bool = False, token=None, **rest
@@ -826,7 +840,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("system", name, flatten=flatten, resolved=resolved)
+        return self.get_item("system", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_repo(
         self, name: str, flatten=False, resolved: bool = False, token=None, **rest
@@ -842,7 +856,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("repo", name, flatten=flatten, resolved=resolved)
+        return self.get_item("repo", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_image(
         self, name: str, flatten=False, resolved: bool = False, token=None, **rest
@@ -858,7 +872,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("image", name, flatten=flatten, resolved=resolved)
+        return self.get_item("image", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_mgmtclass(
         self, name: str, flatten=False, resolved: bool = False, token=None, **rest
@@ -874,7 +888,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("mgmtclass", name, flatten=flatten, resolved=resolved)
+        return self.get_item("mgmtclass", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_package(
         self, name: str, flatten=False, resolved: bool = False, token=None, **rest
@@ -890,7 +904,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("package", name, flatten=flatten, resolved=resolved)
+        return self.get_item("package", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_file(
         self, name: str, flatten=False, resolved: bool = False, token=None, **rest
@@ -906,7 +920,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("file", name, flatten=flatten, resolved=resolved)
+        return self.get_item("file", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_menu(
         self,
@@ -927,7 +941,7 @@ class CobblerXMLRPCInterface:
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("menu", name, flatten=flatten, resolved=resolved)
+        return self.get_item("menu", name, flatten=flatten, resolved=resolved, token=token)
 
     def get_items(self, what: str):
         """
@@ -1235,7 +1249,7 @@ class CobblerXMLRPCInterface:
         else:
             return True
 
-    def get_item_handle(self, what: str, name: str, token=None):
+    def get_item_handle(self, what: str, name: str, token: Optional[str] = None) -> str:
         """
         Given the name of an object (or other search parameters), return a reference (object id) that can be used with
         ``modify_*`` functions or ``save_*`` functions to manipulate that object.
@@ -1245,6 +1259,14 @@ class CobblerXMLRPCInterface:
         :param token: The API-token obtained via the login() method.
         :return: The handle of the desired object.
         """
+        if token in self.transactions:
+            for handle, (iwhat, item, deleted, mtime, base_id) in self.transactions[token].items():
+                if iwhat == what and item.name == name:
+                    if deleted:
+                        raise CX("%s name %s has been deleted in current transaction" % (what, name))
+                    else:
+                        return handle
+
         found = self.api.get_item(what, name)
         if found is None:
             raise CX("internal error, unknown %s name %s" % (what, name))
@@ -1342,6 +1364,73 @@ class CobblerXMLRPCInterface:
         """
         return self.get_item_handle("menu", name, token)
 
+
+    def _transaction_get_modified(self, token, item):
+        if token in self.transactions:
+            handle = item.COLLECTION_TYPE + "::" + item.name
+            if handle in self.transactions[token]:
+                tr_what, tr_item, deleted, mtime, base_id = self.transactions[token][handle]
+                if deleted:
+                    return None
+                return tr_item
+        return item
+
+    def _transaction_children(self, token, item):
+        """
+        The list of children of the same type.
+
+        :getter: An empty list in case of items which don't have logical children.
+        :setter: Replace the list of children completely with the new provided one.
+        """
+        results = []
+        list_items = self.api.get_items(item.COLLECTION_TYPE)
+        for obj in list_items:
+            obj = self._transaction_get_modified(token, obj)
+
+            if obj is None:
+                continue
+            if obj.get_parent == item._name:
+                results.append(obj)
+        return results
+
+
+    def _transaction_tree_walk(self, token, item):
+        """
+        Get all children related by parent/child relationship.
+
+        :return: The list of children objects.
+        """
+        results = []
+        for child in self._transaction_children(token, item):
+            results.append(child)
+            results.extend(self._transaction_tree_walk(token, child))
+
+        return results
+
+    def _transaction_descendants(self, token, obj) -> list:
+        """
+        Get objects that depend on this object, i.e. those that would be affected by a cascading delete, etc.
+
+        .. note:: This is a read only property.
+
+        :getter: This is a list of all descendants. May be empty if none exist.
+        """
+        childs = self._transaction_tree_walk(token, obj)
+        results = set(childs)
+        childs.append(obj)
+        for child in childs:
+            for item_type in item.Item.TYPE_DEPENDENCIES[child.COLLECTION_TYPE]:
+                dep_type_items = self.api.find_items(
+                    item_type[0], {item_type[1]: child.name}
+                )
+                for dep_item in dep_type_items:
+                    dep_item = self._transaction_get_modified(token, dep_item)
+                    if not dep_item or not getattr(dep_item, item_type[1]) or getattr(dep_item, item_type[1]).name != child.name:
+                        continue
+                    results.add(dep_item)
+                    results.update(self._transaction_descendants(token, dep_item))
+        return list(results)
+
     def remove_item(self, what: str, name: str, token: str, recursive: bool = True):
         """
         Deletes an item from a collection.
@@ -1354,6 +1443,20 @@ class CobblerXMLRPCInterface:
         :return: True if the action was successful.
         """
         self._log("remove_item (%s, recursive=%s)" % (what, recursive), name=name, token=token)
+        if token in self.transactions:
+            try:
+                obj_handle = self.get_item_handle(what, name, token)
+                obj = self.__get_object(obj_handle, token)
+            except (ValueError, CX):
+                return False
+            self.check_access(token, f"remove_{what}", obj)
+            self.transactions[token][obj_handle] = (what, obj, True, obj.mtime, obj.uid)
+            if recursive:
+                for k in self._transaction_descendants(token, obj):
+                     self.transactions[token][k.COLLECTION_TYPE + "::" + k.name] = (k.COLLECTION_TYPE, k, True, k.mtime, k.uid)
+
+            return True
+
         obj = self.api.get_item(what, name)
         self.check_access(token, "remove_%s" % what, obj)
         self.api.remove_item(what, name, delete=True, with_triggers=True, recursive=recursive)
@@ -1470,6 +1573,13 @@ class CobblerXMLRPCInterface:
         """
         self._log("copy_item(%s)" % what, object_id=object_id, token=token)
         self.check_access(token, "copy_%s" % what)
+        if token in self.transactions:
+            obj = self.__get_object(object_id, token)
+            obj_copy = obj.make_clone()
+            obj_copy.name = newname
+            self.transactions[token][what + "::" + newname] = (what, obj_copy, False, 0.0, "")
+            return True
+
         obj = self.__get_object(object_id)
         self.api.copy_item(what, obj, newname)
         return True
@@ -1584,6 +1694,19 @@ class CobblerXMLRPCInterface:
         :return: True if the action succeeded.
         """
         self._log("rename_item(%s)" % what, object_id=object_id, token=token)
+        if token in self.transactions:
+            obj = self.__get_object(object_id, token)
+            obj_copy = obj.make_clone()
+            obj_copy.name = newname
+            self.transactions[token][what + "::" + newname] = (what, obj_copy, False, 0.0, "")
+
+            saved_obj = self.api.find_items(what, name=obj.name, return_list=False)
+            if saved_obj is not None:
+                self.transactions[token][what + "::" + saved_obj.name] = (what, saved_obj, True, saved_obj.mtime, saved_obj.uid)
+            else:
+                del self.transactions[token][what + "::" + obj.name]
+            return True
+
         obj = self.__get_object(object_id)
         self.api.rename_item(what, obj, newname)
         return True
@@ -1722,6 +1845,9 @@ class CobblerXMLRPCInterface:
         else:
             raise CX("internal error, collection name is \"%s\"" % what)
         key = "___NEW___%s::%s" % (what, self.__get_random(25))
+        if token in self.transactions:
+            self.transactions[token][key] = (what, d, False, 0.0, "")
+            return key
         self.object_cache[key] = (time.time(), d)
         return key
 
@@ -1828,8 +1954,13 @@ class CobblerXMLRPCInterface:
         :return: True if the action was successful. Otherwise False.
         """
         self._log("modify_item(%s)" % what, object_id=object_id, attribute=attribute, token=token)
-        obj = self.__get_object(object_id)
+        obj = self.__get_object(object_id, token)
         self.check_access(token, "modify_%s" % what, obj, attribute)
+
+        if token in self.transactions and object_id not in self.transactions[token]:
+            new_obj = obj.make_clone()
+            self.transactions[token][object_id] = (what, new_obj, False, obj.mtime, obj.uid)
+            obj = new_obj
 
         if what == "system":
             if attribute == "modify_interface":
@@ -1844,6 +1975,22 @@ class CobblerXMLRPCInterface:
                     new_name=arg.get("rename_interface", "")
                 )
                 return True
+
+        if attribute == "parent" and token in self.transactions:
+            for (_, parent, to_delete, mtime, base_id) in self.transactions[token].values():
+                if parent.name == arg:
+                    if to_delete:
+                        raise ValueError("Parent object has been deleted in current transaction.")
+                    arg = parent
+                    break
+        if attribute == "distro" and token in self.transactions:
+            for (what, distro, to_delete, mtime, base_id) in self.transactions[token].values():
+                if what == "distro" and distro.name == arg:
+                    if to_delete:
+                        raise ValueError("Distro object has been deleted in current transaction.")
+                    arg = distro
+                    break
+
 
         if hasattr(obj, attribute):
             setattr(obj, attribute, arg)
@@ -2206,8 +2353,11 @@ class CobblerXMLRPCInterface:
         :return: True if the action succeeded.
         """
         self._log("save_item(%s)" % what, object_id=object_id, token=token)
-        obj = self.__get_object(object_id)
+        obj = self.__get_object(object_id, token)
         self.check_access(token, "save_%s" % what, obj)
+        if token in self.transactions and object_id in self.transactions[token]:
+            # the object will be saved in commit_transaction()
+            return True
         if editmode == "new":
             self.api.add_item(what, obj, check_for_duplicate_names=True)
         else:
@@ -3746,6 +3896,52 @@ class CobblerXMLRPCInterface:
         """
         return self.api.input_int(value)
 
+    def transaction_begin(self, token: str) -> bool:
+        """
+        Begins a new transaction for the logged-in client.
+        Transactions allow multiple API operations (``new_*``, ``get_*``,
+        ``modify_*``, ``copy_*``, ``remove_*``) to be grouped atomically. All modifications
+        made within a transaction are isolated until committed.
+        Other clients won't see changes until the transaction is committed.
+
+        :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
+        :return: bool if operation was successful
+        """
+        self._log("transaction_begin", token=token)
+        self.transactions[token] = {}
+        return True
+
+    def transaction_commit(self, token: str) -> bool:
+        """
+        Commits a transaction.
+        This performs validation and applies all accumulated transaction operations:
+        1. Checks for conflicting external modifications. If any object was modified
+           outside the transaction (mtime mismatch), the commit fails and all changes
+           are discarded.
+        2. Objects are removed in reverse dependency order (e.g. Profile - Distro)
+        3. Objects are added/modified in dependency order (e.g. Distro - Profile)
+        4. Rebuilds the PXE configuration once at the end
+
+        :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
+        :return: bool if operation was successful
+        """
+        self._log("transaction_commit", token=token)
+        try:
+            self.api.add_remove_items(list(self.transactions[token].values()))
+        finally:
+            del self.transactions[token]
+        return True
+
+    def transaction_abort(self, token: str) -> bool:
+        """
+        Aborts current transaction, all changes are discarded.
+
+        :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
+        :return: bool if operation was successful
+        """
+        self._log("transaction_abort", token=token)
+        del self.transactions[token]
+        return True
 
 # *********************************************************************************
 

--- a/tests/xmlrpcapi/conftest.py
+++ b/tests/xmlrpcapi/conftest.py
@@ -27,6 +27,18 @@ def token(cobbler_xmlrpc_base) -> str:
     """
     return cobbler_xmlrpc_base[1]
 
+@pytest.fixture(scope="function")
+def token2(remote: CobblerXMLRPCInterface) -> str:
+    """
+
+    :param cobbler_xmlrpc_base:
+    :return:
+    """
+    shared_secret = get_shared_secret()
+    token = remote.login("", shared_secret)
+    if not token:
+        raise AssertionError(f"could not obtain a token when logging with {shared_secret}")
+    return token
 
 @pytest.fixture(scope="function")
 def cobbler_xmlrpc_base(cobbler_api):

--- a/tests/xmlrpcapi/transaction_test.py
+++ b/tests/xmlrpcapi/transaction_test.py
@@ -1,0 +1,697 @@
+"""
+Tests that validate the functionality of XML-RPC API transactions.
+"""
+
+import os
+from typing import Callable
+
+import pytest
+
+import cobbler.cexceptions
+from cobbler.remote import CobblerXMLRPCInterface
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "remove_testdistro",
+    "remove_testmenu",
+    "remove_testprofile",
+)
+def test_create_profile(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+):
+    """
+    Test: create/edit a profile object
+    """
+    # Arrange
+    # Act
+    remote.transaction_begin(token)
+    profile = remote.new_profile(token)
+    remote.modify_profile(profile, "name", "testprofile0", token)
+    remote.modify_profile(profile, "distro", "testdistro0", token)
+
+    assert remote.save_profile(profile, token)
+
+    # uncommited profile is not visible without token
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0", None)
+
+    assert remote.transaction_commit(token)
+
+    # now it is visible
+    assert remote.get_item_handle("profile", "testprofile0", None) != "~"
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+    "remove_testprofile",
+)
+def test_modify_profile(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+):
+    """
+    Test: modify a profile object
+    """
+    # Arrange
+    # Act
+    remote.transaction_begin(token)
+    profile = remote.get_profile_handle("testprofile0", token)
+    remote.modify_profile(profile, "comment", "test comment", token)
+
+    assert remote.save_profile(profile, token)
+
+    assert remote.get_profile_handle("testprofile0", None) == profile
+
+    # changes are visible inside the transaction identified by the token
+    assert remote.get_profile("testprofile0", token=token)["comment"] == "test comment"
+
+    # changes are not visible until commit
+    assert remote.get_profile("testprofile0")["comment"] != "test comment"
+    assert remote.transaction_commit(token)
+    assert remote.get_profile("testprofile0")["comment"] == "test comment"
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+    "remove_testprofile",
+)
+def test_copy_profile(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: copy a profile object
+    """
+
+    # Arrange --> Done in fixtures
+
+    # Act
+    remote.transaction_begin(token)
+    profile = remote.get_item_handle("profile", "testprofile0", token)
+    assert remote.copy_profile(profile, "testprofilecopy1", token)
+
+    # without token, the new profile is not visible
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofilecopy1")
+
+    # it is visible inside the transaction identified by the token
+    profile1 = remote.get_item_handle("profile", "testprofilecopy1", token)
+    assert profile1 != "~"
+    assert remote.copy_profile(profile1, "testprofilecopy2", token)
+
+    # without token, the new profiles are not visible
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofilecopy1")
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofilecopy2")
+
+    assert remote.transaction_commit(token)
+    # after commit, everything is visible
+    assert remote.get_item_handle("profile", "testprofilecopy1")
+    assert remote.get_item_handle("profile", "testprofilecopy2")
+
+    # Cleanup
+    remote.remove_profile("testprofilecopy1", token)
+    remote.remove_profile("testprofilecopy2", token)
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+)
+def test_rename_profile(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: copy a profile object
+    """
+
+    # Arrange --> Done in fixtures
+
+    # Act
+    remote.transaction_begin(token)
+    profile = remote.get_item_handle("profile", "testprofile0", token)
+    assert remote.rename_profile(profile, "testprofilerenamed1", token)
+
+    # without token, the original is still visible
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+
+    # without token, the new profile is not visible
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofilerenamed1")
+
+    # it is visible inside the transaction identified by the token
+    profile1 = remote.get_item_handle("profile", "testprofilerenamed1", token)
+    assert profile1 != "~"
+    assert remote.rename_profile(profile1, "testprofilerenamed2", token)
+
+    # without token, the new profiles are not visible
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofilerenamed1")
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofilerenamed2")
+
+    assert remote.transaction_commit(token)
+    # after commit, the new profiles are visible
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofilerenamed1")
+    assert remote.get_item_handle("profile", "testprofilerenamed2") != "~"
+
+    # Cleanup
+    remote.remove_profile("testprofilerenamed2", token)
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+)
+def test_remove_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: remove a profile with descendants
+    """
+
+    # Arrange
+    remote.transaction_begin(token)
+
+    subprofile = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile, "name", "testsubprofile0", token)
+    assert remote.modify_profile(subprofile, "parent", "testprofile0", token)
+    assert remote.save_profile(subprofile, token)
+
+    subprofile1 = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile1, "name", "testsubprofile1", token)
+    assert remote.modify_profile(subprofile1, "parent", "testsubprofile0", token)
+    assert remote.save_profile(subprofile1, token)
+
+    assert remote.transaction_commit(token)
+
+    # Act
+
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    remote.transaction_begin(token)
+    assert remote.remove_profile("testprofile0", token)
+
+    # profiles are visible outside of transaction until commit
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    # inside the transaction identified by the token the profiles are deleted
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0", token)
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile0", token)
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile1", token)
+
+    assert remote.transaction_commit(token)
+
+    # now the profiles are deleted everywhere
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0")
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile0")
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile1")
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+)
+def test_create_profiles(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+):
+    """
+    Test: create/edit multiple profiles
+    """
+    # Arrange
+    # Act
+    remote.transaction_begin(token)
+    for i in range(50):
+        profile = remote.new_profile(token)
+        remote.modify_profile(profile, "name", "testprofile{}".format(i), token)
+        remote.modify_profile(profile, "distro", "testdistro0", token)
+        remote.save_profile(profile, token)
+    assert remote.transaction_commit(token)
+
+    remote.transaction_begin(token)
+    for i in range(50):
+        remote.remove_profile("testprofile{}".format(i), token)
+    assert remote.transaction_commit(token)
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+)
+def test_parent_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: reparent a profile with descendants
+    """
+
+    # Arrange
+
+    profile1 = remote.new_subprofile(token)
+    assert remote.modify_profile(profile1, "name", "testprofile1", token)
+    assert remote.modify_profile(profile1, "parent", "testprofile0", token)
+    assert remote.save_profile(profile1, token)
+
+    profile2 = remote.new_subprofile(token)
+    assert remote.modify_profile(profile2, "name", "testprofile2", token)
+    assert remote.modify_profile(profile2, "parent", "testprofile1", token)
+    assert remote.save_profile(profile2, token)
+
+    profile3 = remote.new_subprofile(token)
+    assert remote.modify_profile(profile3, "name", "testprofile3", token)
+    assert remote.modify_profile(profile3, "parent", "testprofile2", token)
+    assert remote.save_profile(profile3, token)
+
+    # Act
+    assert remote.get_profile("testprofile0")["depth"] == 1
+    assert remote.get_profile("testprofile1")["depth"] == 2
+    assert remote.get_profile("testprofile2")["depth"] == 3
+    assert remote.get_profile("testprofile3")["depth"] == 4
+
+    assert remote.modify_profile(profile2, "parent", "testprofile0", token)
+    assert remote.save_profile(profile2, token)
+
+    assert remote.get_profile("testprofile0")["depth"] == 1
+    assert remote.get_profile("testprofile1")["depth"] == 2
+    assert remote.get_profile("testprofile2")["depth"] == 2
+    #   this seems to be a bug
+    #   assert remote.get_profile("testprofile3")["depth"] == 3
+
+    assert remote.remove_profile("testprofile0", token)
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+)
+def test_reparent_and_delete_profile(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: reparent a profile and delete the old parent in one transaction
+    """
+
+    # Arrange
+
+    subprofile1 = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile1, "name", "testsubprofile0", token)
+    assert remote.modify_profile(subprofile1, "parent", "testprofile0", token)
+    assert remote.save_profile(subprofile1, token)
+
+    subprofile2 = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile2, "name", "testsubprofile1", token)
+    assert remote.modify_profile(subprofile2, "parent", "testprofile0", token)
+    assert remote.save_profile(subprofile2, token)
+
+    # Act
+    remote.transaction_begin(token)
+
+    profile1 = remote.new_profile(token)
+    assert remote.modify_profile(profile1, "name", "testprofile1", token)
+    assert remote.modify_profile(profile1, "distro", "testdistro0", token)
+    assert remote.save_profile(profile1, token)
+
+    subprofile1 = remote.get_item_handle("profile", "testsubprofile0", token)
+
+    assert remote.modify_profile(subprofile1, "parent", "testprofile1", token)
+    assert remote.save_profile(subprofile1, token)
+
+    assert remote.remove_profile("testprofile0", token)
+
+    # the transaction is not visible without the token
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile1")
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    remote.transaction_commit(token)
+
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0")
+    assert remote.get_item_handle("profile", "testprofile1") != "~"
+
+    # this subprofile got the new parent, so it still exists
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+
+    # this subprofile has been deleted with "testprofile0"
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile1")
+
+    # cleanup
+    assert remote.remove_profile("testprofile1", token)
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+)
+def test_conflict(remote: CobblerXMLRPCInterface, token: str, token2: str):
+    """
+    Test: conflicting transactions
+    """
+
+    # Arrange --> Done in fixtures
+
+    # Act
+    remote.transaction_begin(token)
+    profile = remote.get_item_handle("profile", "testprofile0", token)
+    remote.modify_profile(profile, "comment", "test comment", token)
+
+    # delete the original profile before the transaction is finished
+    remote.transaction_begin(token2)
+    assert remote.remove_profile("testprofile0", token2)
+
+    # the first commit is successful
+    assert remote.transaction_commit(token2)
+
+    # the second commit fails because the item has been modified
+    with pytest.raises(ValueError):
+        remote.transaction_commit(token)
+
+    # result of the successfully commited transaction - profile is removed
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0")
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+    "remove_testprofile",
+)
+def test_conflict2(remote: CobblerXMLRPCInterface, token: str, token2: str):
+    """
+    Test: conflicting transactions
+    """
+
+    # Arrange --> Done in fixtures
+
+    # Act
+    remote.transaction_begin(token)
+    profile = remote.get_item_handle("profile", "testprofile0", token)
+    remote.modify_profile(profile, "comment", "test comment", token)
+
+    # delete the original profile before the transaction is finished
+    remote.transaction_begin(token2)
+    assert remote.remove_profile("testprofile0", token2)
+
+    # the first commit is successful
+    assert remote.transaction_commit(token)
+
+    # the second commit fails because the item has been modified
+    with pytest.raises(ValueError):
+        remote.transaction_commit(token2)
+
+    # result of the successfully commited transaction - comment is set
+    assert remote.get_profile("testprofile0")["comment"] == "test comment"
+
+
+@pytest.mark.usefixtures(
+    "create_testmenu",
+    "remove_testdistro",
+    "remove_testmenu",
+    "remove_testprofile",
+)
+def test_create_distro_profile(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+):
+    """
+    Test: create/edit a distro object
+    """
+    # Arrange
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+
+    # Act
+
+    remote.transaction_begin(token)
+    distro = remote.new_distro(token)
+    remote.modify_distro(distro, "name", "testdistro0", token)
+    remote.modify_distro(distro, "kernel", path_kernel, token)
+    remote.modify_distro(distro, "initrd", path_initrd, token)
+
+    assert remote.save_distro(distro, token)
+
+    profile = remote.new_profile(token)
+    remote.modify_profile(profile, "name", "testprofile0", token)
+    remote.modify_profile(profile, "distro", "testdistro0", token)
+
+    assert remote.save_profile(profile, token)
+
+    # uncommited profile is not visible without token
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0")
+
+    # uncommited distro is not visible without token
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("distro", "testdistro0")
+
+    assert remote.transaction_commit(token)
+
+    # now it is visible
+    assert remote.get_item_handle("distro", "testdistro0") != "~"
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+    "remove_testprofile",
+)
+def test_modify_distro(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+):
+    """
+    Test: modify a distro object
+    """
+    # Arrange
+    # Act
+    remote.transaction_begin(token)
+    distro = remote.get_distro_handle("testdistro0", token)
+    remote.modify_distro(distro, "comment", "test comment", token)
+
+    assert remote.save_distro(distro, token)
+
+#    assert remote.get_distro_handle("testdistro0") == distro
+
+    assert remote.get_distro("testdistro0")["comment"] != "test comment"
+    assert remote.transaction_commit(token)
+    assert remote.get_distro("testdistro0")["comment"] == "test comment"
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testmenu",
+)
+def test_remove_distro_recursive(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: remove a distro with descendants
+    """
+
+    # Arrange
+    remote.transaction_begin(token)
+
+    subprofile = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile, "name", "testsubprofile0", token)
+    assert remote.modify_profile(subprofile, "parent", "testprofile0", token)
+    assert remote.save_profile(subprofile, token)
+
+    subprofile1 = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile1, "name", "testsubprofile1", token)
+    assert remote.modify_profile(subprofile1, "parent", "testsubprofile0", token)
+    assert remote.save_profile(subprofile1, token)
+
+    assert remote.transaction_commit(token)
+
+    # Act
+
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    remote.transaction_begin(token)
+    assert remote.remove_distro("testdistro0", token)
+
+    # distro and profiles are visible outside of transaction until commit
+    assert remote.get_item_handle("distro", "testdistro0") != "~"
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    # inside the transaction identified by the token the profiles are deleted
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("distro", "testdistro0", token)
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0", token)
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile0", token)
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile1", token)
+
+    assert remote.transaction_commit(token)
+
+    # now the profiles are deleted everywhere
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("distro", "testdistro0")
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testprofile0")
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile0")
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("profile", "testsubprofile1")
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testmenu",
+)
+def test_reparent_and_remove_distro(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+):
+    """
+    Test: change profile distro to a new one and delete the old disto in one transaction
+    """
+
+    # Arrange
+    remote.transaction_begin(token)
+
+    subprofile = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile, "name", "testsubprofile0", token)
+    assert remote.modify_profile(subprofile, "parent", "testprofile0", token)
+    assert remote.save_profile(subprofile, token)
+
+    subprofile1 = remote.new_subprofile(token)
+    assert remote.modify_profile(subprofile1, "name", "testsubprofile1", token)
+    assert remote.modify_profile(subprofile1, "parent", "testsubprofile0", token)
+    assert remote.save_profile(subprofile1, token)
+
+    assert remote.transaction_commit(token)
+
+    # Act
+
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    remote.transaction_begin(token)
+
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+    distro = remote.new_distro(token)
+    remote.modify_distro(distro, "name", "testdistro1", token)
+    remote.modify_distro(distro, "kernel", path_kernel, token)
+    remote.modify_distro(distro, "initrd", path_initrd, token)
+
+    assert remote.save_distro(distro, token)
+
+    profile = remote.get_item_handle("profile", "testprofile0", token)
+    assert remote.modify_profile(profile, "distro", "testdistro1", token)
+    assert remote.save_profile(profile, token)
+    assert remote.remove_distro("testdistro0", token)
+
+    # distro and profiles are visible outside of transaction until commit
+    assert remote.get_item_handle("distro", "testdistro0") != "~"
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    # inside the transaction identified by the token the distro is deleted
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("distro", "testdistro0", token)
+
+    # the profiles exist
+    assert remote.get_item_handle("profile", "testprofile0", token) != "~"
+    assert remote.get_item_handle("profile", "testsubprofile0", token) != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1", token) != "~"
+
+    assert remote.transaction_commit(token)
+
+    # now the changes are commited
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("distro", "testdistro0")
+    assert remote.get_item_handle("distro", "testdistro1") != "~"
+    assert remote.get_item_handle("profile", "testprofile0") != "~"
+    assert remote.get_profile("testprofile0")["distro"] == "testdistro1"
+
+    assert remote.get_item_handle("profile", "testsubprofile0") != "~"
+    assert remote.get_item_handle("profile", "testsubprofile1") != "~"
+
+    # cleanup
+    assert remote.remove_distro("testdistro1", token)
+
+
+@pytest.mark.usefixtures(
+    "create_testdistro",
+    "create_testmenu",
+    "create_testprofile",
+    "remove_testdistro",
+    "remove_testmenu",
+    "remove_testprofile",
+    "remove_testsystem",
+)
+def test_create_system_positive(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: create/edit a system object
+    """
+    # Act
+    remote.transaction_begin(token)
+    system = remote.new_system(token)
+    remote.modify_system(system, "name", "testsystem0", token)
+    remote.modify_system(system, "profile", "testprofile0", token)
+    assert remote.save_system(system, token)
+
+    # without token, the new system is not visible
+    with pytest.raises(cobbler.cexceptions.CX):
+        remote.get_item_handle("system", "testsystem0")
+    assert remote.transaction_commit(token)
+
+    # Assert
+    assert remote.get_item_handle("system", "testsystem0") != "~"


### PR DESCRIPTION
This is a backport of https://github.com/cobbler/cobbler/pull/3814

## Linked Items

Fixes https://github.com/cobbler/cobbler/issues/3810

## Description

This is an implementation of transactions, as discussed in the related issue.

It fixes the original problem - the speed of creating and deleting of 500 profiles is now under 30s, from the original ~1hour.

## Behaviour changes

Old: No change.

New: Added optional XMLRPC calls begin_transaction(token) and commit_transaction(token)
The modify/save/remove/copy/new operations performed between these calls are stored in memory and are visible
only for the client identified by the token. commit_transaction saves everything and regenerates the menus in one call.