### PR TITLE
uyuni/master: Migrate local changes on settings to dedicated file (bsc#1244027)

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -383,6 +383,48 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %else
 %post
 %systemd_post cobblerd.service
+
+if [ $1 -gt 1 ]; then
+    # In case of a package upgrade
+    if [ -f /etc/susemanager-release ] || [ -f /etc/uyuni-release ]; then
+        if [ -s /etc/cobbler/settings.yaml.rpmnew ] && [ ! -f /etc/cobbler/settings.d/zz-uyuni.settings ]; then
+            # The /etc/cobbler/settings.yaml.backup should exist unless explicitly removed.
+            if [ ! -s /etc/cobbler/settings.yaml.backup ]; then
+                echo "Not found (or empty): /etc/cobbler/settings.yaml.backup - Skipping settings migration"
+            else
+                echo "Migrating Cobbler settings for Uyuni to a dedicated file..."
+                python3 <<EOF
+# Check changes between old defaults (backup) and current settings
+# to detect local changes applied to settings. Local changes are then
+# moved to /etc/cobbler/settings.d/zz-uyuni.settings
+import yaml
+old_backup_settings = None
+current_settings = None
+new_uyuni_settings = {}
+new_uyuni_tftpsync_settings = {}
+with open("/etc/cobbler/settings.yaml.backup") as _input:
+    old_backup_settings = yaml.safe_load(_input)
+with open("/etc/cobbler/settings.yaml") as _input:
+    current_settings = yaml.safe_load(_input)
+for conf in current_settings:
+    if conf == "proxies":
+        new_uyuni_tftpsync_settings[conf] = current_settings[conf]
+    elif conf in old_backup_settings and current_settings[conf] != old_backup_settings[conf]:
+        new_uyuni_settings[conf] = current_settings[conf]
+with open("/etc/cobbler/settings.d/zz-uyuni.settings", "w") as _output:
+    yaml.safe_dump(new_uyuni_settings, _output)
+if new_uyuni_tftpsync_settings:
+    with open("/etc/cobbler/settings.d/zz-uyuni-tftpsync.settings", "w") as _output:
+        yaml.safe_dump(new_uyuni_tftpsync_settings, _output)
+EOF
+                # Restore the default Cobbler settings.yaml file
+                cp /etc/cobbler/settings.yaml /etc/cobbler/settings.yaml.migration.backup
+                mv /etc/cobbler/settings.yaml.rpmnew /etc/cobbler/settings.yaml
+            fi
+        fi
+    fi
+fi
+
 # Fixup permission for world readable settings files
 chmod 640 %{_sysconfdir}/cobbler/settings.yaml
 chmod 600 %{_sysconfdir}/cobbler/mongodb.conf
@@ -443,6 +485,8 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 # Work around broken attr support
 # Cf. https://github.com/debbuild/debbuild/issues/160
 %attr(640, root, root) %config(noreplace) %{_sysconfdir}/cobbler/settings.yaml
+%ghost %{_sysconfdir}/cobbler/settings.yaml.backup
+%ghost %{_sysconfdir}/cobbler/settings.yaml.migration.backup
 %dir %{_sysconfdir}/cobbler/settings.d
 %attr(750, root, root) %{_sysconfdir}/cobbler/settings.d
 %attr(640, root, root) %config(noreplace) %{_sysconfdir}/cobbler/settings.d/bind_manage_ipmi.settings
@@ -453,6 +497,8 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %attr(640, root, root) %config(noreplace) %{_sysconfdir}/cobbler/users.digest
 %else
 %attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/settings.yaml
+%ghost %{_sysconfdir}/cobbler/settings.yaml.backup
+%ghost %{_sysconfdir}/cobbler/settings.yaml.migration.backup
 %attr(750, root, root) %dir %{_sysconfdir}/cobbler/settings.d
 %attr(640, root, root) %config(noreplace) %{_sysconfdir}/cobbler/settings.d/bind_manage_ipmi.settings
 %attr(640, root, root) %config(noreplace) %{_sysconfdir}/cobbler/settings.d/manage_genders.settings


### PR DESCRIPTION
This PR migrates local changes in the Cobbler settings to a dedicated settings file when running on an Uyuni or SUSE Multi-Linux Manager environment.

- New dedicated settings file: `/etc/cobbler/settings.d/zz-uyuni.settings`

On a containerized environment, before this change, there are always the following files:

- `/etc/cobbler/settings.yaml` -> containing old default settings + local changes
- `/etc/cobbler/settings.yaml.backup` -> old default settings without any local changes
- `/etc/cobbler/settings.yaml.rpmnew`-> new default settings (not taken into account)

The migration process does the following:
- Detect local changes by comparing `/etc/cobbler/settings.yaml` and `/etc/cobbler/settings.yaml.backup`
- Move local settings to new `/etc/cobbler/settings.d/zz-uyuni.settings` file
- Restore new defaults by moving `/etc/cobbler/settings.yaml.rpmnew` to `/etc/cobbler/settings.yaml`

After this migration, the `/etc/cobbler/settings.yaml` will contain no local changes and therefore will get the posible changes coming from Cobbler upgrades.

NOTE: Migration only runs if `/etc/cobbler/settings.d/zz-uyuni.settings` is not yet existing.

IMPORTANT: This PR needs to be merge in coordination with these other PRs:
https://github.com/uyuni-project/uyuni/pull/10585
https://github.com/SUSE/spacewalk/pull/27904
https://github.com/uyuni-project/uyuni-tools/pull/628

Tracks: https://github.com/SUSE/spacewalk/issues/27412

