### PR TITLE
suma/head: fix "test_grubimage_run" on Uyuni/MLM test containers

### DIFF
--- a/tests/actions/mkloaders_test.py
+++ b/tests/actions/mkloaders_test.py
@@ -28,8 +28,8 @@ def test_grubimage_run(cobbler_api, mocker):
 
     # Assert
     # On a full install: 3 common formats, 4 syslinux links and 9 bootloader formats
-    # In our Uyuni/SUMA test container we have: shim (1x), ipxe (1x), syslinux v4 (3x) and 1 grub (1x)
-    assert mkloaders.symlink.call_count == 6
+    # In our Uyuni/SUMA test container we have: ipxe (1x), syslinux v4 (3x) and grub (3x)
+    assert mkloaders.symlink.call_count == 7
     # In our Uyuni/SUMA test container we have: x86_64
     assert mkloaders.mkimage.call_count == 2
 


### PR DESCRIPTION
This PR fixes the expectations of a failing test (excluded on GH actions) on `suma/head` branch, that is causing a failure in our Uyuni/MLM testing containers [0]:

```console
actions/mkloaders_test.py .F
>>> traceback >>>

cobbler_api = <cobbler.api.CobblerAPI object at 0x7f845a0c3048>, mocker = <pytest_mock.plugin.MockFixture object at 0x7f845a0c30f0>

    def test_grubimage_run(cobbler_api, mocker):
        # Arrange
        test_image_creator = mkloaders.MkLoaders(cobbler_api)
        mocker.patch("cobbler.actions.mkloaders.symlink", spec=cobbler.actions.mkloaders.symlink)
        mocker.patch("cobbler.actions.mkloaders.mkimage", spec=cobbler.actions.mkloaders.mkimage)
    
        # Act
        test_image_creator.run()
    
        # Assert
        # On a full install: 3 common formats, 4 syslinux links and 9 bootloader formats
        # In our Uyuni/SUMA test container we have: shim (1x), ipxe (1x), syslinux v4 (3x) and 1 grub (1x)
>       assert mkloaders.symlink.call_count == 6
E       AssertionError: assert 7 == 6
E        +  where 7 = <MagicMock name='symlink' spec='function' id='140206442936752'>.call_count
E        +    where <MagicMock name='symlink' spec='function' id='140206442936752'> = mkloaders.symlink

actions/mkloaders_test.py:32: AssertionError

(Pdb) mkloaders.symlink.call_args_list
[call(PosixPath('/usr/share/ipxe/undionly.kpxe'), PosixPath('/var/lib/cobbler/loaders/undionly.pxe'), skip_existing=True),
 call(PosixPath('/usr/share/syslinux/menu.c32'), PosixPath('/var/lib/cobbler/loaders/menu.c32'), skip_existing=True),
 call(PosixPath('/usr/share/syslinux/memdisk'), PosixPath('/var/lib/cobbler/loaders/memdisk'), skip_existing=True),
 call(PosixPath('/usr/share/syslinux/pxelinux.0'), PosixPath('/var/lib/cobbler/loaders/pxelinux.0'), skip_existing=True),
 call(PosixPath('/usr/share/grub2/i386-pc'), PosixPath('/var/lib/cobbler/loaders/grub/i386-pc'), skip_existing=True),
 call(PosixPath('/usr/share/grub2/x86_64-efi'), PosixPath('/var/lib/cobbler/loaders/grub/x86_64-efi'), skip_existing=True),
 call(PosixPath('/usr/share/grub2/x86_64-efi/grub.efi'), PosixPath('/var/lib/cobbler/loaders/grub/grub.efi'), skip_existing=True)]
```

This PR fixes the expectations after adding a new loader on https://github.com/openSUSE/cobbler/pull/108

No upstream PR for this, as upstream has different expectations.

[0] https://ci.suse.de/view/Manager/view/Manager-5.0/job/manager-5.0-dev-Cobbler-Tests/346/console