### PR TITLE
Compatibility fixes for tftpboot directory setup - suma/head

### DIFF
--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -75,6 +75,13 @@ class MkLoaders:
             skip_existing=True
         )
 
+        # compatibility symlink in case the firmware looks in the root directory
+        symlink(
+            self.bootloaders_dir.joinpath(pathlib.Path("grub/shim.efi")),
+            self.bootloaders_dir.joinpath(pathlib.Path("shim.efi")),
+            skip_existing=True
+        )
+
     def make_ipxe(self):
         """
         Create symlink of the iPXE bootloader in case it is available on the system.
@@ -163,6 +170,13 @@ class MkLoaders:
                 symlink(
                     target_grub,
                     self.bootloaders_dir.joinpath("grub", binary_name),
+                    skip_existing=True,
+                )
+
+                # compatibility symlink in case shim looks in the root directory
+                symlink(
+                    self.bootloaders_dir.joinpath("grub", binary_name),
+                    self.bootloaders_dir.joinpath(binary_name),
                     skip_existing=True,
                 )
                 self.logger.info(

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -200,6 +200,9 @@ class CobblerSync:
             utils.mkdir(self.links)
         if not os.path.exists(self.distromirror_config):
             utils.mkdir(self.distromirror_config)
+        boot_link = os.path.join(self.bootloc, "boot")
+        if not os.path.exists(boot_link):
+            os.symlink(".", boot_link, target_is_directory=True)
 
     def clean_trees(self):
         """

--- a/config/grub/grub.cfg
+++ b/config/grub/grub.cfg
@@ -1,8 +1,8 @@
 # jloeser: workaround for all machines requesting grub.cfg from tftpboot root
 #          directory (e.g. firmware bug in p8 LPAR and (some?) OVMF)
-if [ -r "${prefix}grub/grub.cfg" ]; then
+if [ -r "${prefix}/grub/grub.cfg" ]; then
   echo "grub missing from prefix='${prefix}'. Please fix firmware..."
-  set prefix="${prefix}grub"
+  set prefix="${prefix}/grub"
   configfile "${prefix}/grub.cfg"
 else
   echo "Unexpected prefix='${prefix}'. Please fix firmware or grub binary..."

--- a/setup.py
+++ b/setup.py
@@ -604,7 +604,6 @@ if __name__ == "__main__":
             # files
             ("%s/grub_config/grub" % libpath, glob("config/grub/grub/*")),
             # dirs
-            ("%s/boot" % tftproot, []),
             ("%s/etc" % tftproot, []),
             ("%s/grub" % tftproot, []),
             ("%s/images" % tftproot, []),


### PR DESCRIPTION
Port of https://github.com/openSUSE/cobbler/pull/143

Fixes compatibility problems:
- migrated Retail branch server formulas have typically configured  `/boot/grub.efi`, `/boot/shim.efi` or `/boot/pxelinux.0` in dhcp. This PR makes this work via compatibility link.
- sometimes, `shim.efi` loads `grub.efi` from toplevel directory, it probably depends on firmware. This PR adds these files also to the toplevel directory.
- handle prefix without trailing `/` in toplevel grub.cfg

In the cobbler RPM package, `/srv/tftpboot/boot` is an empty directory. This PR removes it and replaces it with a symlink in the code.

Details in https://github.com/SUSE/spacewalk/issues/28342