### PR TITLE
Fix mkloaders test

### DIFF
--- a/cobbler.changes
+++ b/cobbler.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr 15 07:10:27 UTC 2026 - Marek Czernek <marek.czernek@suse.com>
+
+- Fix failing mkloaders test
+
+-------------------------------------------------------------------
 Thu Nov 20 14:06:30 UTC 2025 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Compatibility fixes for tftpboot directory setup

--- a/tests/actions/mkloaders_test.py
+++ b/tests/actions/mkloaders_test.py
@@ -28,8 +28,8 @@ def test_grubimage_run(cobbler_api, mocker):
 
     # Assert
     # On a full install: 3 common formats, 4 syslinux links and 9 bootloader formats
-    # In our Uyuni/SUMA test container we have: ipxe (1x), syslinux v4 (3x) and grub (3x)
-    assert mkloaders.symlink.call_count == 7
+    # In our Uyuni/SUMA test container we have: ipxe (1x), syslinux v4 (3x) and grub (4x)
+    assert mkloaders.symlink.call_count == 8
     # In our Uyuni/SUMA test container we have: x86_64
     assert mkloaders.mkimage.call_count == 2
 


### PR DESCRIPTION
In https://github.com/openSUSE/cobbler/pull/143, we have increased the number of symlinks by one. The test failure was not caught by Github CI, because we explicitly skip mkloaders_test. However, the internal CI is showing this fail. 

Before https://github.com/openSUSE/cobbler/pull/143, we created 7 symlinks:

```
Call 0: call(PosixPath('/usr/share/ipxe/undionly.kpxe'), PosixPath('/var/lib/cobbler/loaders/undionly.pxe'), skip_existing=True)
Call 1: call(PosixPath('/usr/share/syslinux/menu.c32'), PosixPath('/var/lib/cobbler/loaders/menu.c32'), skip_existing=True)
Call 2: call(PosixPath('/usr/share/syslinux/memdisk'), PosixPath('/var/lib/cobbler/loaders/memdisk'), skip_existing=True)
Call 3: call(PosixPath('/usr/share/syslinux/pxelinux.0'), PosixPath('/var/lib/cobbler/loaders/pxelinux.0'), skip_existing=True)
Call 4: call(PosixPath('/usr/share/grub2/i386-pc'), PosixPath('/var/lib/cobbler/loaders/grub/i386-pc'), skip_existing=True)
Call 5: call(PosixPath('/usr/share/grub2/x86_64-efi'), PosixPath('/var/lib/cobbler/loaders/grub/x86_64-efi'), skip_existing=True)
Call 6: call(PosixPath('/usr/share/grub2/x86_64-efi/grub.efi'), PosixPath('/var/lib/cobbler/loaders/grub/grub.efi'), skip_existing=True)
```

After this change, the following symlink call is added:

```
Call 7: call(PosixPath('/var/lib/cobbler/loaders/grub/grub.efi'), PosixPath('/var/lib/cobbler/loaders/grub.efi'), skip_existing=True)
```