### PR TITLE
Adjust Release number to proper 0

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -154,7 +154,7 @@
 
 Name:           cobbler
 Version:        3.3.3
-Release:        1%{?dist}
+Release:        0%{?dist}
 Summary:        Boot server configurator
 URL:            https://cobbler.github.io/
 


### PR DESCRIPTION
If we build this package in OBS we need the standard `0` here in the release number