### PR TITLE
uyuni/master: Add support for building with Python 3.13

### DIFF
--- a/cobbler.changes
+++ b/cobbler.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May  5 14:20:39 UTC 2026 - Pablo Suárez Hernández <pablo.suarezhernandez@suse.com>
+
+- Add support for building with Python 3.13
+
+-------------------------------------------------------------------
 Wed Apr 15 07:10:27 UTC 2026 - Marek Czernek <marek.czernek@suse.com>
 
 - Fix failing mkloaders test

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,12 @@ from setuptools import Command
 from setuptools.command.install import install as _install
 from setuptools import Distribution as _Distribution
 from setuptools.command.build_py import build_py as _build_py
-from setuptools import dep_util
+
+try:
+    from setuptools import modified as dep_util
+except ImportError:
+    from setuptools import dep_util
+
 from distutils.command.build import build as _build
 from configparser import ConfigParser
 from setuptools import find_packages


### PR DESCRIPTION
This PR fixes an issue building Cobbler on Python 3.13, needed for building Uyuni on top of openSUSE Leap 16.0.

No upstream PR needed due to `setup.py` refactor.