### PR TITLE
uyuni/master: add workaround for "roman-numerals-py" in spec file

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -303,6 +303,19 @@ Dockerfiles and scripts to setup testing containers
 %prep
 %setup
 
+%if 0%{?suse_version} >= 1600
+# The current version of pip in Leap 16.0 tries to pull roman-numerals-py
+# from PyPI even if the package is provided via RPM as BuildRequires.
+# Workaround: Spoof the metadata for roman-numerals-py so
+# setuptools transitive dependency checks don't hit the internet.
+mkdir -p roman_numerals_py-99.9.9.egg-info
+cat <<EOF > roman_numerals_py-99.9.9.egg-info/PKG-INFO
+Metadata-Version: 2.1
+Name: roman-numerals-py
+Version: 99.9.9
+EOF
+%endif
+
 %if 0%{?suse_version}
 # Set tftpboot location correctly for SUSE distributions
 sed -e "s|/var/lib/tftpboot|%{tftpboot_dir}|g" -i config/cobbler/settings.yaml


### PR DESCRIPTION
Somehow, during buildtime of Cobbler on openSUSE Leap 16.0, there is a transient python dependency (`roman-numerals-py`) that, even if provided via `BuildRequires: python313-roman-numerals`, it is not detected properly by the python build system.

Notice the difference: `roman-numerals-py` vs `python-roman-numerals`.

This makes the build system to download it from PyPI, which fails in OBS (as no internet connection).

I've tried to fix this via "Substitute" in the projectconfig but I had no luck, so I'm pushing this workaround for now to the spec file, to trick the build system so it does not try to download this dependency.

The package seems to be working fine with the workaround: https://build.opensuse.org/package/show/home:PSuarezHernandez:branches:systemsmanagement:Uyuni:Master/cobbler

NOTE: I'm not adding a changelog entry for this, as the previous one already apply to this change and we have not released them yet.