### PR TITLE
uyuni/master: rel-eng: make rsync to use checksum to determine files to copy

### DIFF
--- a/rel-eng/get-changes-from-github.sh
+++ b/rel-eng/get-changes-from-github.sh
@@ -124,7 +124,7 @@ if [[ "$NEEDS_PUSH" == true ]]; then
     mkdir -p "$PACKAGE_NAME"
 
     # Sync sources (excluding git metadata)
-    rsync -a --delete --exclude='.git' ../source_repo/ "$PACKAGE_NAME/"
+    rsync -a --checksum --delete --exclude='.git' ../source_repo/ "$PACKAGE_NAME/"
 
     # Extract the .spec and .changes files
     for ext in spec changes; do


### PR DESCRIPTION
This PR fixes a problem happening on the rsync call, when source and target files have same size and same modified time. When this happens, the rsync will exclude this file to be copied even if there are actual changes.

With this PR, we pass the `--checksum` flag to rsync to it really checks if the files are different to sync them. 