### PR TITLE
mlm/head: rel-eng: make rsync to use checksum to determine files to copy

### DIFF
--- a/rel-eng/get-changes-from-github.sh
+++ b/rel-eng/get-changes-from-github.sh
@@ -124,7 +124,7 @@ if [[ "$NEEDS_PUSH" == true ]]; then
     mkdir -p "$PACKAGE_NAME"
 
     # Sync sources (excluding git metadata)
-    rsync -a --delete --exclude='.git' ../source_repo/ "$PACKAGE_NAME/"
+    rsync -a --checksum --delete --exclude='.git' ../source_repo/ "$PACKAGE_NAME/"
 
     # Extract the .spec and .changes files
     for ext in spec changes; do


### PR DESCRIPTION
This PR backports https://github.com/openSUSE/cobbler/pull/163 to `mlm/head`  branch.