### PR TITLE
Fix not needed whitespace in changelog

### DIFF
--- a/cobbler.changes
+++ b/cobbler.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu May 21 10:40:01 UTC 2026 - Abid Mehmood <amehmood@suse.com>
 
-- Added the distro signature for rhel10(bsc#1265134)
+- Added the distro signature for rhel10 (bsc#1265134)
 
 -------------------------------------------------------------------
 Wed May 20 12:23:24 UTC 2026 - Pablo Suárez Hernández <pablo.suarezhernandez@suse.com>


### PR DESCRIPTION
Just one white space was missing from the last changelog entry.