### PR TITLE
Fix issue due distutils removal on Python 3.13

### DIFF
--- a/cobbler.changes
+++ b/cobbler.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun  3 11:03:32 UTC 2026 - Pablo Suárez Hernández <pablo.suarezhernandez@suse.com>
+
+- Fix issue due distutils removal on Python 3.13
+
+-------------------------------------------------------------------
 Thu May 21 10:40:01 UTC 2026 - Abid Mehmood <amehmood@suse.com>
 
 - Added the distro signature for rhel10 (bsc#1265134)

--- a/cobbler/modules/managers/genders.py
+++ b/cobbler/modules/managers/genders.py
@@ -1,13 +1,9 @@
-import distutils.sysconfig
 import logging
 import sys
 import os
 import time
 from cobbler.templar import Templar
 
-plib = distutils.sysconfig.get_python_lib()
-mod_path = "%s/cobbler" % plib
-sys.path.insert(0, mod_path)
 template_file = "/etc/cobbler/genders.template"
 settings_file = "/etc/genders"
 

--- a/svc/services.py
+++ b/svc/services.py
@@ -38,8 +38,21 @@ def application(environ, start_response):
         # VIRTUALENV Support
         # see http://code.google.com/p/modwsgi/wiki/VirtualEnvironments
         import site
-        import distutils.sysconfig
-        site.addsitedir(distutils.sysconfig.get_python_lib(prefix=environ['VIRTUALENV']))
+        import sys
+
+        venv_prefix = environ['VIRTUALENV']
+        if sys.version_info >= (3, 11):
+            import sysconfig
+            venv_site_packages = sysconfig.get_path(
+                'purelib',
+                scheme='venv',
+                vars={'base': venv_prefix, 'platbase': venv_prefix}
+            )
+        else:
+            import distutils.sysconfig
+            venv_site_packages = distutils.sysconfig.get_python_lib(prefix=venv_prefix)
+
+        site.addsitedir(venv_site_packages)
         # Now all modules are available even under a virtualenv
 
     from cobbler.services import CobblerSvc


### PR DESCRIPTION
This PR fixes some issue when running Cobbler on openSUSE Leap 16.0 (Python 3.13):

```
[Daemon] 2026-06-03T07:04:15 - INFO | Exception occurred: <class 'ModuleNotFoundError'>
[Daemon] 2026-06-03T07:04:15 - INFO | Exception value: No module named 'distutils'
[Daemon] 2026-06-03T07:04:15 - INFO | Exception Info:
  File "/usr/lib/python3.13/site-packages/cobbler/module_loader.py", line 95, in __import_module
    blip = import_module("cobbler.modules.%s" % modname)
  File "/usr/lib64/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1395, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/usr/lib/python3.13/site-packages/cobbler/modules/managers/genders.py", line 1, in <module>
    import distutils.sysconfig
```

In Python 3.13, distutils was removed, so we need to adjust the code to use `sysconfig` on this recent Python versions.

NOTE: For `cobbler/modules/managers/genders.py` I think it is safe to drop this part completely, as Python site-packages should be already part of Python paths.